### PR TITLE
feat: publish Docker image to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,38 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ["v[0-9]+.[0-9]+.[0-9]+"]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/eric-becker/floodgate
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Publishes `ghcr.io/eric-becker/floodgate:latest` on every merge to `main`
- Publishes versioned tags (`v0.1.1`, `0.1`, etc.) on release tag pushes
- Uses `GITHUB_TOKEN` — no extra secrets required

## Usage after merge

Once this merges, the image is available at:
```
ghcr.io/eric-becker/floodgate:latest
```

For the `flmesh/emqx` docker-compose, use:
```yaml
floodgate:
  image: ghcr.io/eric-becker/floodgate:latest
  restart: unless-stopped
  volumes:
    - ./floodgate-config.yaml:/app/config.yaml:ro
  depends_on:
    - emqx
```

Or pin to a specific release:
```yaml
image: ghcr.io/eric-becker/floodgate:v0.1.1
```

## Test plan
- [ ] CI (test matrix) passes
- [ ] Docker workflow runs and image appears at `ghcr.io/eric-becker/floodgate`
- [ ] Image is public (check package visibility in GitHub settings if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)