### PR TITLE
fix: container and k8s security hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,6 @@ ENV PYTHONUNBUFFERED=1
 
 EXPOSE 9000
 
+USER nobody
+
 ENTRYPOINT ["python", "-m", "floodgate"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,8 +19,6 @@ services:
 
   floodgate:
     build: .
-    ports:
-      - "9000:9000"     # ExHook gRPC
     environment:
       FLOODGATE_CONFIG: /app/config.yaml
     volumes:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: floodgate
-          image: eric-becker/floodgate:latest
+          image: ghcr.io/eric-becker/floodgate:latest
           ports:
             - containerPort: 9000
               protocol: TCP
@@ -34,6 +34,13 @@ spec:
             limits:
               cpu: 200m
               memory: 128Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
       volumes:
         - name: config
           configMap:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "GPL-3.0-or-later"
 requires-python = ">=3.11"
 dependencies = [
-    "grpcio>=1.60.0",
+    "grpcio>=1.80.0",
     "protobuf>=4.25.0",
     "paho-mqtt>=2.0.0",
     "pyyaml>=6.0",
@@ -18,7 +18,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "grpcio-tools>=1.60.0",
+    "grpcio-tools>=1.80.0",
     "pytest>=7.0",
 ]
 


### PR DESCRIPTION
## Summary
- Run container as `nobody` (UID 65534) instead of root
- Add k8s `securityContext`: `runAsNonRoot`, `readOnlyRootFilesystem`, drop all capabilities
- Fix k8s image reference to `ghcr.io/eric-becker/floodgate:latest` (was missing registry prefix)
- Remove port `9000` from `docker-compose.yaml` host binding — gRPC is internal only, no reason to expose it to the host
- Align `pyproject.toml` grpcio floor with `requirements.txt` (`>=1.80.0`)

## Test plan
- [ ] CI passes
- [ ] Docker image builds and starts without error
- [ ] Container process confirms non-root: `docker run --rm --entrypoint id ghcr.io/eric-becker/floodgate:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)