### PR TITLE
chore: add --clobber to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,5 @@ jobs:
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
             --generate-notes \
-            --verify-tag
+            --verify-tag \
+            --clobber


### PR DESCRIPTION
Prevents failure if a tag already has a release (e.g. manually created). --clobber updates the existing release instead of erroring.


🤖 Generated with [Claude Code](https://claude.com/claude-code)