### PR TITLE
fix: remove --clobber from gh release create

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,5 +35,4 @@ jobs:
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
             --generate-notes \
-            --verify-tag \
-            --clobber
+            --verify-tag


### PR DESCRIPTION
`--clobber` is not a valid flag in the `gh` version on Actions runners. Removing it — not needed since release tags are unique.

Fixes the v0.2.0 release job failure.