### PR TITLE
refactor: rename to zerohop, structured JSON logging, blacklist default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Gateway → EMQX → [ExHook gRPC] → floodgate → modified payload → EMQX �
 | File | Role |
 |------|------|
 | `src/floodgate/exhook_server.py` | gRPC server; EMQX connects here |
-| `src/floodgate/antiflood.py` | Core logic: packet decode, zerohop, logging |
+| `src/floodgate/zerohop.py` | Core logic: packet decode, zerohop, logging |
 | `src/floodgate/config.py` | Config loader; channel policy evaluation |
 | `src/floodgate/__main__.py` | CLI entry point |
 | `proto/emqx/exhook.proto` | EMQX ExHook interface definition |
@@ -56,7 +56,8 @@ After startup, register the ExHook in EMQX (see docker-compose.yaml header for t
 
 | Key | Default | Effect |
 |-----|---------|--------|
-| `channel_policy` | `whitelist` | `whitelist`: zerohop all except listed. `blacklist`: zerohop only listed. |
+| `channel_policy` | `blacklist` | `blacklist` (default): zerohop only listed channels. `whitelist`: zerohop all except listed. |
+| `channel_blacklist` | 8 standard presets | Channels to zerohop (blacklist mode). Default = all standard Meshtastic public presets. |
 | `channel_whitelist` | `[]` | Channels exempt from zerohop (whitelist mode). Empty = zerohop everything. |
-| `channel_blacklist` | standard presets | Channels to zerohop (blacklist mode). |
-| `log_level` | `INFO` | Set to `DEBUG` for per-message outcome logs. |
+| `log_level` | `INFO` | `INFO` logs per-message outcomes. `DEBUG` adds decode/gRPC internals. |
+| `log_format` | `text` | `text` (default) or `json` for Loki/Grafana. Override with `FLOODGATE_LOG_FORMAT` env var. |

--- a/README.md
+++ b/README.md
@@ -118,44 +118,57 @@ See [k8s/](k8s/) — Deployment, Service, and ConfigMap. Register the ExHook at 
 pip install -e ".[dev]"
 
 floodgate --config config.yaml
-floodgate --config config.yaml -v  # DEBUG per-message logging
+floodgate --config config.yaml -v  # very verbose DEBUG logging
 ```
 
 ## Configuration
 
+See [config.yaml](config.yaml) for a fully annotated example.
+
 | Key | Default | Description |
 |-----|---------|-------------|
-| `channel_policy` | `whitelist` | `whitelist`: zero-hop all except listed. `blacklist`: zero-hop only listed. |
-| `channel_whitelist` | `[]` | Channels exempt from zero-hop (whitelist mode). Empty = zero-hop all. |
-| `channel_blacklist` | standard presets | Channels to zero-hop (blacklist mode). |
+| `channel_policy` | `blacklist` | See policy docs below. |
+| `channel_blacklist` | 8 standard presets | Channels to zero-hop (blacklist mode). |
+| `channel_whitelist` | `[]` | Channels exempt from zero-hop (whitelist mode). |
 | `topic_filter` | `msh/#` | MQTT topic pattern to apply. |
 | `grpc_port` | `9000` | gRPC listen port. |
 | `health_port` | `8080` | HTTP health check port. `GET /health` returns `{"status":"ok","stats":{...}}`. |
-| `stats_interval_s` | `60` | Stats log interval in seconds. `0` disables. |
-| `log_level` | `INFO` | `DEBUG` enables per-message outcome logs. |
+| `stats_interval_s` | `60` | Stats log interval in seconds. |
+| `log_level` | `INFO` | `INFO` shows per-message outcomes. `DEBUG` adds verbose internals. |
+| `log_format` | `text` | `text` for human-readable output, `json` for Loki/Grafana structured logging. Can also be set via `FLOODGATE_LOG_FORMAT` env var. |
 
-See [config.yaml](config.yaml) for a fully annotated example.
+### Channel policy
 
-**Whitelist mode** — zero-hop everything except named channels:
+**`blacklist` (default)** — zero-hop only the channels named in `channel_blacklist`. All other channels are forwarded unchanged. This is the right choice for most deployments: it targets the standard Meshtastic public presets that flood radio networks, while leaving private or custom channels untouched.
+
+The default `channel_blacklist` contains the eight standard Meshtastic public channel presets:
 ```yaml
-channel_policy: whitelist
-channel_whitelist:
-  - MyPrivateChannel
-```
-
-**Blacklist mode** — zero-hop only named channels:
-```yaml
-channel_policy: blacklist
+channel_policy: "blacklist"
 channel_blacklist:
-  - LongFast
-  - LongModerate
+  - "LongTurbo"
+  - "LongFast"
+  - "LongModerate"
+  - "MediumFast"
+  - "MediumSlow"
+  - "ShortFast"
+  - "ShortSlow"
+  - "ShortTurbo"
 ```
 
-## Deployment
+**`whitelist`** — zero-hop ALL channels *except* those named in `channel_whitelist`. Use this for blanket enforcement when you want every channel zeroed with only specific exemptions.
 
-**Docker Compose** — see [docker-compose.yaml](docker-compose.yaml). Runs floodgate alongside EMQX OSS.
+To zero-hop every packet with no exceptions — maximum enforcement — use an empty whitelist:
+```yaml
+channel_policy: "whitelist"
+channel_whitelist: []
+```
 
-**Kubernetes** — see [k8s/](k8s/). Apply manifests and register the ExHook at `http://floodgate:9000`.
+To exempt specific channels (e.g. a private channel your gateways should rebroadcast normally):
+```yaml
+channel_policy: "whitelist"
+channel_whitelist:
+  - "MyPrivateChannel"
+```
 
 ## Development
 
@@ -164,11 +177,11 @@ pip install -e ".[dev]"
 pytest tests/ -q   # no protobufs required — protobuf imports are mocked
 ```
 
-**Log format (DEBUG):**
+**Log output (INFO, text mode):**
 ```
-[ZEROHOP]  topic=msh/2/e/LongFast/!a2e1a8c4  channel=LongFast  id=3827461829  hop_start=3
-[PASSTHRU] topic=msh/2/e/MyPrivate/!a2e1a8c4  channel=MyPrivate  id=1234567890
-[STATS]    zerohop=142  noop=3  passthru=0  warn=0  (last 60s)
+2024-03-30 14:23:47 INFO     [floodgate.zerohop] [ZEROHOP]  topic=msh/US/2/e/LongFast/!a2e1a8c4  channel=LongFast  encoding=e  hop 3→0  id=3827461829  from=!a2e1a8c4  to=^all
+2024-03-30 14:23:48 INFO     [floodgate.zerohop] [PASSTHRU] topic=msh/US/2/e/MyPrivate/!a2e1a8c4  channel=MyPrivate  id=1234567890
+2024-03-30 14:24:47 INFO     [floodgate.exhook_server] Stats [last 60s]  zerohopped=142   passthru=3    noop=0    skipped=1050  errors=0    total=1195
 ```
 
 ## Legal

--- a/config.yaml
+++ b/config.yaml
@@ -1,13 +1,35 @@
 # floodgate configuration
 
-# Channel policy: "whitelist" zero-hops ALL channels EXCEPT those listed below.
-#                 "blacklist" zero-hops ONLY channels listed below.
-channel_policy: "whitelist"
+# ---------------------------------------------------------------------------
+# Channel policy
+# ---------------------------------------------------------------------------
+#
+# Controls which channels get zero-hopped (hop_limit set to 0 in-flight).
+#
+# Two modes:
+#
+#   blacklist  (default)
+#     Zero-hop only the channels listed in channel_blacklist.
+#     All other channels are forwarded unchanged.
+#     Use this to target specific well-known public channels while leaving
+#     private or custom channels alone.
+#
+#   whitelist
+#     Zero-hop ALL channels EXCEPT those listed in channel_whitelist.
+#     Use this when you want blanket zero-hop enforcement with only a few
+#     named exemptions.
+#     To zero-hop every packet with no exceptions, set channel_whitelist: []
+#
+# Default: blacklist targeting the eight standard Meshtastic public presets.
+# This is the recommended starting point for most deployments — it enforces
+# the zero-hop policy on public channels that flood radio networks while
+# leaving your private/custom channels untouched.
+#
+channel_policy: "blacklist"
 
-# Channels exempt from zero-hopping (whitelist policy). Empty = zero-hop everything.
-channel_whitelist: []
-
-# Channels to zero-hop (blacklist policy). Standard Meshtastic public channel presets.
+# Channels to zero-hop (blacklist policy).
+# These are the eight standard Meshtastic public channel presets.
+# Remove any channel your deployment does not use, or add custom names.
 channel_blacklist:
   - "LongTurbo"
   - "LongFast"
@@ -17,6 +39,14 @@ channel_blacklist:
   - "ShortFast"
   - "ShortSlow"
   - "ShortTurbo"
+
+# Channels exempt from zero-hopping (whitelist policy only).
+# Has no effect when channel_policy is "blacklist".
+# Empty list means zero-hop ALL channels — use this for maximum enforcement.
+# Example: to exempt a private channel, add it here:
+#   channel_whitelist:
+#     - "MyPrivateChannel"
+channel_whitelist: []
 
 # ExHook gRPC port — must match the URL registered in EMQX.
 grpc_port: 9000
@@ -31,5 +61,12 @@ topic_filter: "msh/#"
 stats_interval_s: 60
 
 # Log level: DEBUG, INFO, WARNING, ERROR
-# DEBUG emits per-message outcome lines — useful for verifying behavior.
+# INFO emits per-message outcome lines ([ZEROHOP]/[PASSTHRU]/[NOOP]) — recommended for normal operation.
+# DEBUG adds very verbose internals (decode steps, byte counts, gRPC calls).
 log_level: "INFO"
+
+# Log output format: "text" (default, human-readable) or "json" (structured, for Loki/Grafana).
+# Can also be set via the FLOODGATE_LOG_FORMAT environment variable (overrides this file).
+# JSON mode emits one JSON object per line with fields: level, timestamp, message,
+# outcome, topic, channel, encoding, packet_id, from_node, to_node, hop_from, hop_to.
+log_format: "text"

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: floodgate-config
 data:
   config.yaml: |
-    channel_policy: "whitelist"
+    channel_policy: "blacklist"
     channel_whitelist: []
     channel_blacklist:
       - "LongTurbo"
@@ -16,6 +16,8 @@ data:
       - "ShortSlow"
       - "ShortTurbo"
     grpc_port: 9000
+    health_port: 8080
     topic_filter: "msh/#"
     stats_interval_s: 60
     log_level: "INFO"
+    log_format: "text"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "protobuf>=4.25.0",
     "paho-mqtt>=2.0.0",
     "pyyaml>=6.0",
+    "python-json-logger>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ grpcio-tools>=1.80.0
 protobuf>=4.25.0
 paho-mqtt>=2.0.0
 pyyaml>=6.0
+python-json-logger>=2.0

--- a/src/floodgate/__main__.py
+++ b/src/floodgate/__main__.py
@@ -2,7 +2,6 @@
 
 import argparse
 import logging
-import sys
 
 from . import __version__
 from .config import load_config
@@ -28,15 +27,17 @@ def main():
         "-v", "--verbose",
         action="store_true",
         help=(
-            "Enable DEBUG logging — emits [ZEROHOP]/[PASSTHRU]/[NOOP]/[SKIP] "
-            "for every message processed. Equivalent to log_level: DEBUG in config.yaml."
+            "Enable DEBUG logging — very verbose (decode steps, byte counts, gRPC calls). "
+            "INFO already shows per-message outcomes ([ZEROHOP]/[PASSTHRU]/[NOOP]). "
+            "Equivalent to log_level: DEBUG in config.yaml."
         ),
     )
 
     args = parser.parse_args()
 
+    # Bootstrap with plain text so load_config() INFO/WARN messages are visible
     logging.basicConfig(
-        level=logging.DEBUG if args.verbose else logging.INFO,
+        level=logging.INFO,
         format="%(asctime)s %(levelname)-8s [%(name)s] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
@@ -47,6 +48,11 @@ def main():
         config["log_level"] = "DEBUG"
 
     log_level = getattr(logging, config.get("log_level", "INFO").upper(), logging.INFO)
+    log_format = config.get("log_format", "text")
+
+    # Install real handler (potentially JSON), replacing the bootstrap handler
+    from .log_setup import configure_logging
+    configure_logging(log_level, log_format)
     logging.getLogger("floodgate").setLevel(log_level)
 
     logger = logging.getLogger("floodgate")

--- a/src/floodgate/config.py
+++ b/src/floodgate/config.py
@@ -10,7 +10,7 @@ import yaml
 logger = logging.getLogger(__name__)
 
 DEFAULT_CONFIG = {
-    "channel_policy": "whitelist",
+    "channel_policy": "blacklist",
     "channel_whitelist": [],
     "channel_blacklist": [
         "LongTurbo",
@@ -31,6 +31,7 @@ DEFAULT_CONFIG = {
     # How often (seconds) to emit a rolling stats summary at INFO level
     "stats_interval_s": 60,
     "log_level": "INFO",
+    "log_format": "text",   # "text" | "json"
 }
 
 
@@ -50,6 +51,11 @@ def load_config(config_path: str | None = None) -> dict[str, Any]:
             _deep_merge(config, user_config)
         else:
             logger.warning("Config file %s not found, using defaults", path)
+
+    # ENV var override for log_format — convenient for Docker/k8s without touching config files
+    env_fmt = os.environ.get("FLOODGATE_LOG_FORMAT")
+    if env_fmt is not None:
+        config["log_format"] = env_fmt.lower()
 
     # Pre-compute sets for fast lookup
     # Use 'or []' to guard against YAML null (channel_whitelist: with no entries)

--- a/src/floodgate/exhook_server.py
+++ b/src/floodgate/exhook_server.py
@@ -6,7 +6,8 @@ from concurrent import futures
 
 import grpc
 
-from .antiflood import process_message, stats as antiflood_stats
+from .zerohop import process_message
+from .zerohop import stats as packet_stats
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,10 @@ class HookProviderServicer:
 
     def OnMessagePublish(self, request, context):
         msg = request.message
+        logger.debug("OnMessagePublish: topic=%s bytes=%d", msg.topic, len(msg.payload))
         modified_payload = process_message(msg.topic, msg.payload, self.config)
+        result = "modified" if modified_payload is not None else "pass"
+        logger.debug("OnMessagePublish: result=%s", result)
 
         resp = _exhook_pb2.ValuedResponse()
         if modified_payload is not None:
@@ -131,7 +135,7 @@ class HookProviderServicer:
 def _stats_reporter(interval_s: int, stop_event: threading.Event):
     """Log rolling stats every interval_s seconds (resets counters each cycle)."""
     while not stop_event.wait(timeout=interval_s):
-        snap = antiflood_stats.reset()
+        snap = packet_stats.reset()
         if snap["total"] > 0:
             logger.info(
                 "Stats [last %ds]  zerohopped=%-4d  passthru=%-4d  noop=%-4d"
@@ -139,6 +143,16 @@ def _stats_reporter(interval_s: int, stop_event: threading.Event):
                 interval_s,
                 snap["zerohopped"], snap["passthru"], snap["noop"],
                 snap["skipped"],    snap["errors"],   snap["total"],
+                extra={
+                    "event":       "stats",
+                    "interval_s":  interval_s,
+                    "zerohopped":  snap["zerohopped"],
+                    "passthru":    snap["passthru"],
+                    "noop":        snap["noop"],
+                    "skipped":     snap["skipped"],
+                    "errors":      snap["errors"],
+                    "total":       snap["total"],
+                },
             )
         else:
             logger.debug("Stats [last %ds]  no meshtastic messages received", interval_s)
@@ -174,7 +188,8 @@ def _log_startup_policy(config: dict):
 
     logger.info("Stats will be logged every %d seconds", interval)
     logger.info(
-        "Set log_level: DEBUG (or run with -v) to see per-message outcome logs"
+        "Per-message outcomes ([ZEROHOP]/[PASSTHRU]/[NOOP]) logged at INFO.  "
+        "Run with -v for verbose DEBUG."
     )
 
 
@@ -190,8 +205,13 @@ def serve(config: dict):
     _exhook_pb2_grpc.add_HookProviderServicer_to_server(
         HookProviderServicer(config), server
     )
-    server.add_insecure_port(f"[::]:{port}")
-    server.start()
+    try:
+        server.add_insecure_port(f"[::]:{port}")
+        server.start()
+    except Exception as exc:
+        logger.error("Failed to start gRPC server on port %d: %s(%s)",
+                     port, type(exc).__name__, exc, exc_info=True)
+        raise
 
     from .health import start_health_server
     start_health_server(health_port)
@@ -211,5 +231,9 @@ def serve(config: dict):
 
     try:
         server.wait_for_termination()
+    except Exception as exc:
+        logger.error("gRPC server terminated unexpectedly: %s(%s)",
+                     type(exc).__name__, exc, exc_info=True)
+        raise
     finally:
         stop_event.set()

--- a/src/floodgate/health.py
+++ b/src/floodgate/health.py
@@ -5,7 +5,7 @@ import logging
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
-from .antiflood import stats as antiflood_stats
+from .zerohop import stats as packet_stats
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ class _HealthHandler(BaseHTTPRequestHandler):
         if self.path == "/health":
             body = json.dumps({
                 "status": "ok",
-                "stats": antiflood_stats.snapshot(),
+                "stats": packet_stats.snapshot(),
             }).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")

--- a/src/floodgate/log_setup.py
+++ b/src/floodgate/log_setup.py
@@ -1,0 +1,32 @@
+"""Logging formatter setup — text (default) or JSON (for Loki/Grafana)."""
+
+import logging
+
+
+def build_formatter(log_format: str) -> logging.Formatter:
+    """Return a Formatter for the requested format ('text' or 'json')."""
+    if log_format == "json":
+        try:
+            from pythonjsonlogger.json import JsonFormatter
+        except ImportError:
+            from pythonjsonlogger.jsonlogger import JsonFormatter  # type: ignore[no-redef]
+
+        return JsonFormatter(
+            fmt="%(asctime)s %(levelname)s %(name)s %(message)s",
+            rename_fields={"levelname": "level", "asctime": "timestamp"},
+            datefmt="%Y-%m-%dT%H:%M:%SZ",
+        )
+    return logging.Formatter(
+        fmt="%(asctime)s %(levelname)-8s [%(name)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+
+def configure_logging(level: int, log_format: str) -> None:
+    """Install root handler with correct formatter, replacing any prior handler."""
+    handler = logging.StreamHandler()
+    handler.setFormatter(build_formatter(log_format))
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(level)

--- a/src/floodgate/zerohop.py
+++ b/src/floodgate/zerohop.py
@@ -4,7 +4,6 @@ import json as _json
 import logging
 import threading
 from dataclasses import dataclass, field
-from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +15,7 @@ def _load_protos():
     global _mqtt_pb2, _mesh_pb2
     if _mqtt_pb2 is None:
         try:
-            from meshtastic import mqtt_pb2, mesh_pb2
+            from meshtastic import mesh_pb2, mqtt_pb2
             _mqtt_pb2 = mqtt_pb2
             _mesh_pb2 = mesh_pb2
         except ImportError:
@@ -83,7 +82,7 @@ stats = AntifloodStats()
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _fmt_node(node_id: Optional[int]) -> str:
+def _fmt_node(node_id: int | None) -> str:
     """Format a full Meshtastic node ID for display."""
     if node_id is None:
         return "?"
@@ -118,7 +117,7 @@ def _fmt_meta(meta: dict) -> str:
 # Topic parsing
 # ---------------------------------------------------------------------------
 
-def parse_meshtastic_topic(topic: str) -> Optional[Tuple[str, str]]:
+def parse_meshtastic_topic(topic: str) -> tuple[str, str] | None:
     """Parse a Meshtastic MQTT topic and return (channel, encoding) if it is a
     processable packet topic, otherwise None.
 
@@ -219,7 +218,7 @@ def _extract_proto_meta(pkt) -> dict:
     return meta
 
 
-def zerohop_protobuf(payload: bytes) -> Tuple[Optional[bytes], Optional[int], dict]:
+def zerohop_protobuf(payload: bytes) -> tuple[bytes | None, int | None, dict]:
     """Zero-hop a protobuf ServiceEnvelope.
 
     Returns (modified_bytes, original_hop_limit, packet_meta):
@@ -231,6 +230,8 @@ def zerohop_protobuf(payload: bytes) -> Tuple[Optional[bytes], Optional[int], di
     try:
         envelope = _mqtt_pb2.ServiceEnvelope()
         envelope.ParseFromString(payload)
+        logger.debug("zerohop_protobuf: parsed %d bytes, has_packet=%s",
+                     len(payload), envelope.HasField("packet"))
 
         if not envelope.HasField("packet"):
             logger.debug("ServiceEnvelope has no packet field")
@@ -238,12 +239,14 @@ def zerohop_protobuf(payload: bytes) -> Tuple[Optional[bytes], Optional[int], di
 
         pkt = envelope.packet
         old_hop = pkt.hop_limit
+        logger.debug("zerohop_protobuf: old_hop=%d", old_hop)
         if old_hop == 0:
             meta = _extract_proto_meta(pkt)
             return None, 0, meta
 
         envelope.packet.hop_limit = 0
         modified = envelope.SerializeToString()
+        logger.debug("zerohop_protobuf: serialized %d bytes", len(modified))
 
     except Exception as exc:
         logger.warning("Failed to parse protobuf payload (%d bytes): %s(%s)",
@@ -254,7 +257,7 @@ def zerohop_protobuf(payload: bytes) -> Tuple[Optional[bytes], Optional[int], di
     return modified, old_hop, meta
 
 
-def zerohop_json(payload: bytes) -> Tuple[Optional[bytes], Optional[int], dict]:
+def zerohop_json(payload: bytes) -> tuple[bytes | None, int | None, dict]:
     """Zero-hop a JSON-encoded Meshtastic packet.
 
     Meshtastic JSON format omits 'hop_limit' and uses 'hops_away' instead:
@@ -267,6 +270,7 @@ def zerohop_json(payload: bytes) -> Tuple[Optional[bytes], Optional[int], dict]:
     """
     try:
         data = _json.loads(payload)
+        logger.debug("zerohop_json: parsed %d bytes, keys=%s", len(payload), list(data.keys()))
     except Exception as exc:
         logger.warning("Failed to parse JSON payload (%d bytes): %s(%s)",
                        len(payload), type(exc).__name__, exc)
@@ -299,18 +303,31 @@ def zerohop_json(payload: bytes) -> Tuple[Optional[bytes], Optional[int], dict]:
 # Main entry point
 # ---------------------------------------------------------------------------
 
-def process_message(topic: str, payload: bytes, config: dict) -> Optional[bytes]:
+def process_message(topic: str, payload: bytes, config: dict) -> bytes | None:
     """Process one MQTT message; return modified payload or None (pass-through).
 
     Non-packet msh/ topics (map reports, stat topics, etc.) are silently
     ignored and counted under 'skipped' in stats.
 
-    Processed packet outcomes are logged at DEBUG level:
+    Processed packet outcomes are logged at INFO level:
       [ZEROHOP]   modified, subscribers receive hop_limit=0
       [PASSTHRU]  channel exempted by policy, subscribers receive original
       [NOOP]      hop_limit was already 0, no change
       [WARN]      payload could not be parsed — original forwarded unchanged
     """
+    try:
+        return _process_message_inner(topic, payload, config)
+    except Exception as exc:
+        stats.inc("errors")
+        logger.error(
+            "Unhandled exception processing topic=%s: %s(%s)",
+            topic, type(exc).__name__, exc,
+            exc_info=True,
+        )
+        return None
+
+
+def _process_message_inner(topic: str, payload: bytes, config: dict) -> bytes | None:
     from .config import should_zerohop
 
     parsed = parse_meshtastic_topic(topic)
@@ -324,11 +341,21 @@ def process_message(topic: str, payload: bytes, config: dict) -> Optional[bytes]
 
     if not should_zerohop(config, channel):
         stats.inc("passthru")
-        if logger.isEnabledFor(logging.DEBUG):
-            meta = _peek_meta(encoding, payload)
-            pkt_fields = _fmt_meta(meta)
-            logger.debug("[PASSTHRU] topic=%s  channel=%s%s",
-                         topic, channel, f"  {pkt_fields}" if pkt_fields else "")
+        meta = _peek_meta(encoding, payload)
+        pkt_fields = _fmt_meta(meta)
+        logger.info(
+            "[PASSTHRU] topic=%s  channel=%s%s",
+            topic, channel, f"  {pkt_fields}" if pkt_fields else "",
+            extra={
+                "outcome":    "passthru",
+                "topic":      topic,
+                "channel":    channel,
+                "encoding":   encoding,
+                "packet_id":  meta.get("packet_id"),
+                "from_node":  _fmt_node(meta.get("sender")),
+                "to_node":    _fmt_node(meta.get("destination")),
+            },
+        )
         return None
 
     if encoding == "json":
@@ -343,22 +370,51 @@ def process_message(topic: str, payload: bytes, config: dict) -> Optional[bytes]
         logger.warning(
             "[WARN]     topic=%s  channel=%s  could not parse %d-byte payload",
             topic, channel, len(payload),
+            extra={
+                "outcome":   "warn",
+                "topic":     topic,
+                "channel":   channel,
+                "encoding":  encoding,
+                "bytes":     len(payload),
+            },
         )
         return None
 
     if old_hop == 0:
         stats.inc("noop")
-        logger.debug(
+        logger.info(
             "[NOOP]     topic=%s  channel=%s  hop_limit already 0%s",
             topic, channel,
             ("  " + pkt_fields) if pkt_fields else "",
+            extra={
+                "outcome":    "noop",
+                "topic":      topic,
+                "channel":    channel,
+                "encoding":   encoding,
+                "packet_id":  meta.get("packet_id"),
+                "from_node":  _fmt_node(meta.get("sender")),
+                "to_node":    _fmt_node(meta.get("destination")),
+                "hop_from":   0,
+                "hop_to":     0,
+            },
         )
         return None
 
     stats.inc("zerohopped")
-    logger.debug(
-        "[ZEROHOP]  topic=%s  channel=%s  encoding=%s  hop %d→0%s",
+    logger.info(
+        "[ZEROHOP]  topic=%s  channel=%s  encoding=%s  hop %d\u21920%s",
         topic, channel, encoding, old_hop,
         ("  " + pkt_fields) if pkt_fields else "",
+        extra={
+            "outcome":    "zerohop",
+            "topic":      topic,
+            "channel":    channel,
+            "encoding":   encoding,
+            "packet_id":  meta.get("packet_id"),
+            "from_node":  _fmt_node(meta.get("sender")),
+            "to_node":    _fmt_node(meta.get("destination")),
+            "hop_from":   old_hop,
+            "hop_to":     0,
+        },
     )
     return modified

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,5 @@
 """Tests for configuration loading and channel policy logic."""
 
-import pytest
 import yaml
 
 from floodgate.config import load_config, should_zerohop
@@ -14,13 +13,21 @@ class TestShouldZerohop:
         assert should_zerohop(config, "MyPrivateChannel") is True
 
     def test_whitelist_with_entries_passes_through(self):
-        config = {"channel_policy": "whitelist", "_whitelist_set": {"PrivateChannel", "MyGroup"}, "_blacklist_set": set()}
+        config = {
+            "channel_policy": "whitelist",
+            "_whitelist_set": {"PrivateChannel", "MyGroup"},
+            "_blacklist_set": set(),
+        }
         assert should_zerohop(config, "LongFast") is True
         assert should_zerohop(config, "PrivateChannel") is False
         assert should_zerohop(config, "MyGroup") is False
 
     def test_blacklist_zerohops_listed(self):
-        config = {"channel_policy": "blacklist", "_whitelist_set": set(), "_blacklist_set": {"LongFast", "ShortFast"}}
+        config = {
+            "channel_policy": "blacklist",
+            "_whitelist_set": set(),
+            "_blacklist_set": {"LongFast", "ShortFast"},
+        }
         assert should_zerohop(config, "LongFast") is True
         assert should_zerohop(config, "MyPrivate") is False
 
@@ -37,7 +44,7 @@ class TestLoadConfig:
 
     def test_default_config(self):
         config = load_config(None)
-        assert config["channel_policy"] == "whitelist"
+        assert config["channel_policy"] == "blacklist"
         assert config["channel_whitelist"] == []
         assert len(config["channel_blacklist"]) == 8
         assert config["grpc_port"] == 9000
@@ -61,7 +68,7 @@ class TestLoadConfig:
 
     def test_missing_file_uses_defaults(self):
         config = load_config("/nonexistent/config.yaml")
-        assert config["channel_policy"] == "whitelist"
+        assert config["channel_policy"] == "blacklist"
 
     def test_sets_are_computed(self):
         config = load_config(None)
@@ -73,3 +80,20 @@ class TestLoadConfig:
         cfg_file.write_text(yaml.dump({"stats_interval_s": 300}))
         config = load_config(str(cfg_file))
         assert config["stats_interval_s"] == 300
+
+    def test_default_log_format(self):
+        config = load_config(None)
+        assert config["log_format"] == "text"
+
+    def test_log_format_from_yaml(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(yaml.dump({"log_format": "json"}))
+        config = load_config(str(cfg_file))
+        assert config["log_format"] == "json"
+
+    def test_log_format_env_overrides_yaml(self, tmp_path, monkeypatch):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(yaml.dump({"log_format": "text"}))
+        monkeypatch.setenv("FLOODGATE_LOG_FORMAT", "json")
+        config = load_config(str(cfg_file))
+        assert config["log_format"] == "json"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -2,15 +2,12 @@
 
 import json
 import threading
-import urllib.request
 import urllib.error
+import urllib.request
 from http.server import HTTPServer
 
-import pytest
-
-from floodgate.antiflood import stats as antiflood_stats
 from floodgate.health import _HealthHandler, start_health_server
-
+from floodgate.zerohop import stats as packet_stats
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -42,12 +39,12 @@ class TestHealthEndpoint:
 
     def setup_method(self):
         # Reset stats counters before each test so they don't bleed across tests
-        with antiflood_stats._lock:
-            antiflood_stats.zerohopped = 0
-            antiflood_stats.passthru = 0
-            antiflood_stats.noop = 0
-            antiflood_stats.skipped = 0
-            antiflood_stats.errors = 0
+        with packet_stats._lock:
+            packet_stats.zerohopped = 0
+            packet_stats.passthru = 0
+            packet_stats.noop = 0
+            packet_stats.skipped = 0
+            packet_stats.errors = 0
 
     def test_health_returns_200(self):
         server, base = _start_test_server()
@@ -86,9 +83,9 @@ class TestHealthEndpoint:
             server.shutdown()
 
     def test_health_stats_reflect_counters(self):
-        antiflood_stats.zerohopped = 5
-        antiflood_stats.passthru = 2
-        antiflood_stats.noop = 1
+        packet_stats.zerohopped = 5
+        packet_stats.passthru = 2
+        packet_stats.noop = 1
 
         server, base = _start_test_server()
         try:

--- a/tests/test_log_setup.py
+++ b/tests/test_log_setup.py
@@ -1,0 +1,53 @@
+"""Tests for JSON and text formatter setup."""
+
+import json
+import logging
+
+from floodgate.log_setup import build_formatter
+
+
+class TestBuildFormatter:
+
+    def test_text_formatter_is_standard(self):
+        fmt = build_formatter("text")
+        assert isinstance(fmt, logging.Formatter)
+        record = logging.LogRecord("test", logging.INFO, "", 0, "hello", (), None)
+        output = fmt.format(record)
+        assert "hello" in output
+        assert "INFO" in output
+
+    def test_json_formatter_emits_valid_json(self):
+        fmt = build_formatter("json")
+        record = logging.LogRecord("test", logging.INFO, "", 0, "hello", (), None)
+        output = fmt.format(record)
+        data = json.loads(output)
+        assert data["message"] == "hello"
+        assert "level" in data
+        assert "levelname" not in data   # must be renamed to "level"
+
+    def test_json_formatter_includes_extra_fields(self):
+        fmt = build_formatter("json")
+        record = logging.LogRecord("test", logging.INFO, "", 0, "zerohop", (), None)
+        record.outcome  = "zerohop"
+        record.channel  = "LongFast"
+        record.hop_from = 3
+        record.hop_to   = 0
+        output = fmt.format(record)
+        data = json.loads(output)
+        assert data["outcome"]  == "zerohop"
+        assert data["channel"]  == "LongFast"
+        assert data["hop_from"] == 3
+        assert data["hop_to"]   == 0
+
+    def test_json_formatter_level_value(self):
+        fmt = build_formatter("json")
+        record = logging.LogRecord("test", logging.WARNING, "", 0, "oops", (), None)
+        data = json.loads(fmt.format(record))
+        assert data["level"] in ("WARNING", "WARN")
+
+    def test_json_formatter_has_timestamp(self):
+        fmt = build_formatter("json")
+        record = logging.LogRecord("test", logging.INFO, "", 0, "ts", (), None)
+        data = json.loads(fmt.format(record))
+        assert "timestamp" in data
+        assert "asctime" not in data     # must be renamed to "timestamp"

--- a/tests/test_zerohop.py
+++ b/tests/test_zerohop.py
@@ -1,13 +1,10 @@
-"""Tests for core antiflood (zero-hop) logic."""
+"""Tests for core zero-hop packet processing logic."""
 
 import json
+import logging
 from unittest.mock import patch
 
-import pytest
-
-import logging
-
-from floodgate.antiflood import (
+from floodgate.zerohop import (
     _peek_meta,
     parse_meshtastic_topic,
     process_message,
@@ -33,7 +30,8 @@ class TestParseMetastasticTopic:
         assert parse_meshtastic_topic("") is None
 
     def test_private_channel(self):
-        assert parse_meshtastic_topic("msh/US/2/e/MyPrivateChannel/!aabbccdd") == ("MyPrivateChannel", "e")
+        result = parse_meshtastic_topic("msh/US/2/e/MyPrivateChannel/!aabbccdd")
+        assert result == ("MyPrivateChannel", "e")
 
     def test_deep_topic_three_prefix_parts(self):
         # msh/{country}/{region}/2/e/LongFast/!nodeId — 3-part prefix
@@ -150,21 +148,21 @@ class TestProcessMessage:
 
     def test_whitelist_empty_zerohops_proto(self):
         config = self._config(policy="whitelist")
-        with patch("floodgate.antiflood.zerohop_protobuf") as mock_zh:
+        with patch("floodgate.zerohop.zerohop_protobuf") as mock_zh:
             mock_zh.return_value = (b"modified", 3, {})
             result = process_message("msh/US/FL/2/e/LongFast/!1234", b"proto", config)
         assert result == b"modified"
 
     def test_whitelist_empty_zerohops_json(self):
         config = self._config(policy="whitelist")
-        with patch("floodgate.antiflood.zerohop_json") as mock_zh:
+        with patch("floodgate.zerohop.zerohop_json") as mock_zh:
             mock_zh.return_value = (b'{"hop_limit":0}', 3, {})
             result = process_message("msh/US/FL/2/json/LongFast/!1234", b"json", config)
         assert result == b'{"hop_limit":0}'
 
     def test_whitelist_empty_zerohops_deep_topic(self):
         config = self._config(policy="whitelist")
-        with patch("floodgate.antiflood.zerohop_protobuf") as mock_zh:
+        with patch("floodgate.zerohop.zerohop_protobuf") as mock_zh:
             mock_zh.return_value = (b"modified", 3, {})
             result = process_message("msh/US/FL/LWS/2/e/LongFast/!16cec9ac", b"proto", config)
         assert result == b"modified"
@@ -181,7 +179,7 @@ class TestProcessMessage:
 
     def test_blacklist_zerohops_listed(self):
         config = self._config(policy="blacklist", blacklist=["LongFast"])
-        with patch("floodgate.antiflood.zerohop_protobuf") as mock_zh:
+        with patch("floodgate.zerohop.zerohop_protobuf") as mock_zh:
             mock_zh.return_value = (b"modified", 3, {})
             result = process_message("msh/US/2/e/LongFast/!1234", b"proto", config)
         assert result == b"modified"
@@ -193,14 +191,14 @@ class TestProcessMessage:
 
     def test_already_zero_returns_none(self):
         config = self._config(policy="whitelist")
-        with patch("floodgate.antiflood.zerohop_protobuf") as mock_zh:
+        with patch("floodgate.zerohop.zerohop_protobuf") as mock_zh:
             mock_zh.return_value = (None, 0, {})
             result = process_message("msh/US/2/e/LongFast/!1234", b"proto", config)
         assert result is None
 
     def test_parse_error_returns_none(self):
         config = self._config(policy="whitelist")
-        with patch("floodgate.antiflood.zerohop_protobuf") as mock_zh:
+        with patch("floodgate.zerohop.zerohop_protobuf") as mock_zh:
             mock_zh.return_value = (None, None, {})
             result = process_message("msh/US/2/e/LongFast/!1234", b"bad", config)
         assert result is None
@@ -215,7 +213,7 @@ class TestProcessMessage:
             "via_mqtt":    True,
             "relay_node":  0xAB,
         }
-        with patch("floodgate.antiflood.zerohop_protobuf") as mock_zh:
+        with patch("floodgate.zerohop.zerohop_protobuf") as mock_zh:
             mock_zh.return_value = (b"modified", 3, meta)
             result = process_message("msh/US/2/e/LongFast/!1234", b"proto", config)
         assert result == b"modified"
@@ -262,7 +260,7 @@ class TestPeekMeta:
         }
         payload = json.dumps({"id": 99999, "from": 1, "to": 4294967295,
                               "hop_start": 3, "hops_away": 0}).encode()
-        with caplog.at_level(logging.DEBUG, logger="floodgate.antiflood"):
+        with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
             result = process_message("msh/US/2/json/LongFast/!aabbccdd", payload, config)
         assert result is None
         assert "99999" in caplog.text


### PR DESCRIPTION
## Summary

- **Renames `antiflood.py` → `zerohop.py`** (and `test_antiflood.py` → `test_zerohop.py`). All import paths, `patch()` targets, and logger names updated. Git detected the rename at 80% similarity.

- **Structured logging overhaul** for Grafana Loki integration:
  - New `log_setup.py` — selectable `text` (default) or `json` formatter. JSON mode renames `levelname→level` and `asctime→timestamp` for Loki auto-detection.
  - New `log_format` config key (`"text"|"json"`); also settable via `FLOODGATE_LOG_FORMAT` env var for Docker/k8s convenience without touching config files.
  - Per-message outcomes (`[ZEROHOP]`/`[PASSTHRU]`/`[NOOP]`) promoted from DEBUG → INFO. Every outcome carries structured `extra={}` fields (`outcome`, `topic`, `channel`, `encoding`, `packet_id`, `from_node`, `to_node`, `hop_from`, `hop_to`) that surface as top-level fields in JSON mode.
  - Stats log carries integer fields (`zerohopped`, `passthru`, `noop`, `skipped`, `errors`, `total`) enabling `sum_over_time` LogQL aggregation.
  - New ERROR level for unhandled exceptions and gRPC server failures.
  - DEBUG is now truly verbose internals (decode steps, byte counts, gRPC entry). `-v` help text updated.

- **Default policy changed to `blacklist`**: targets the eight standard Meshtastic public presets by default, leaving private/custom channels untouched. The previous `whitelist` default offered no protection without explicit configuration. `config.yaml`, `k8s/configmap.yaml`, and README updated with full policy documentation including the whitelist `[]` recipe for zero-hopping everything.

- **Dependency**: `python-json-logger>=2.0` (zero transitive deps).

## Test plan

- [ ] `pytest tests/ --ignore=tests/test_container_smoke.py -q` passes (66 unit tests)
- [ ] Verify `FLOODGATE_LOG_FORMAT=json floodgate --config config.yaml` emits one JSON object per line with `level` field (not `levelname`) and per-message fields (`outcome`, `channel`, etc.)
- [ ] Verify default run (`log_format: text`) is visually identical to previous output