### PR TITLE
fix: make release job idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          gh release view "${{ github.ref_name }}" 2>/dev/null || \
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
             --generate-notes \


### PR DESCRIPTION
## Summary

- Check if GitHub release already exists before attempting to create it
- Prevents the release job from failing when a tag is pushed for an already-existing release (as happened with v0.2.0)

## Test plan

- [ ] Verify release workflow passes on next tag push