### PR TITLE
feat: optimize structured logging for Loki/Grafana

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ After startup, register the ExHook in EMQX (see docker-compose.yaml header for t
 | `channel_whitelist` | `[]` | Channels exempt from zero-hop (whitelist mode). Empty = zero-hop everything. |
 | `log_level` | `INFO` | `INFO` logs per-message outcomes. `DEBUG` adds decode/gRPC internals. |
 | `log_format` | `text` | `text` (default) or `json` for Loki/Grafana. Override with `FLOODGATE_LOG_FORMAT` env var. |
+| `stats_log` | `true` | Log periodic stats summaries. Set `false` to disable. |
 
 ## Documentation and Test Discipline
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,16 @@ Before:  hop_limit: 3  hop_start: 3
 After:   hop_limit: 0  hop_start: 3  ← hop_start preserved for observability
 ```
 
+See [Meshtastic Mesh Algorithm](https://meshtastic.org/docs/overview/mesh-algo/) for details on `hop_limit` and `hop_start`.
+
 Each message produces one outcome:
 
 | Outcome | Condition |
 |---------|-----------|
-| `[ZEROHOP]` | Channel matched policy, `hop_limit > 0` — zeroed |
-| `[NOOP]` | Channel matched policy, already `hop_limit=0` |
-| `[PASSTHRU]` | Channel exempt by policy — unchanged |
-| `[WARN]` | Payload parse failure — unchanged |
+| `zerohop` | Channel matched policy, `hop_limit > 0` — zeroed |
+| `noop` | Channel matched policy, already `hop_limit=0` |
+| `passthru` | Channel exempt by policy — unchanged |
+| `warn` | Payload parse failure — unchanged |
 
 ## Deployment
 
@@ -123,6 +125,7 @@ See [config.yaml](config.yaml) for a fully annotated example.
 | `grpc_port` | `9000` | gRPC listen port. |
 | `health_port` | `8080` | HTTP health check port. `GET /health` returns `{"status":"ok","stats":{...}}`. |
 | `stats_interval_s` | `60` | Stats log interval in seconds. |
+| `stats_log` | `true` | Log periodic stats summaries. Set `false` to disable. |
 | `log_level` | `INFO` | `INFO` shows per-message outcomes. `DEBUG` adds verbose internals. |
 | `log_format` | `text` | `text` for human-readable output, `json` for Loki/Grafana structured logging. Can also be set via `FLOODGATE_LOG_FORMAT` env var. |
 
@@ -190,7 +193,7 @@ curl -s http://localhost:8080/health | jq .
 {
   "status": "ok",
   "stats": {
-    "zerohopped": 142,
+    "zerohop": 142,
     "passthru": 3,
     "noop": 0,
     "skipped": 1050,
@@ -202,26 +205,28 @@ curl -s http://localhost:8080/health | jq .
 
 ### Log output
 
-Per-message outcomes are logged at **INFO** — no special flags required:
+Per-message outcomes are logged at **INFO** — no special flags required. Field names match [Meshtastic protobuf terminology](https://meshtastic.org/docs/overview/mesh-algo/) (`hop_limit`, `hop_start`, `from`, `to`, `id`).
 
+**Text mode** (default):
 ```
-2026-04-01 12:00:01 INFO     [floodgate.zerohop] [ZEROHOP]  topic=msh/US/2/e/LongFast/!a2e1a8c4  channel=LongFast  encoding=e  hop 3→0  id=3827461829  from=!a2e1a8c4  to=^all
-2026-04-01 12:00:02 INFO     [floodgate.zerohop] [NOOP]     topic=msh/US/2/e/LongFast/!b3c4d5e6  channel=LongFast  encoding=e  hop 0→0  id=2019283746  from=!b3c4d5e6  to=^all
-2026-04-01 12:00:15 INFO     [floodgate.zerohop] [PASSTHRU] topic=msh/US/2/e/MyPrivate/!a2e1a8c4  channel=MyPrivate  encoding=e  id=1234567890  from=!a2e1a8c4  to=^all
-2026-04-01 12:01:01 INFO     [floodgate.exhook_server] Stats [last 60s]  zerohopped=142   passthru=1    noop=0    skipped=1050  errors=0    total=1193
-```
-
-For **structured JSON output** (Loki/Grafana ingestion), set `log_format: json` in config or:
-
-```bash
-FLOODGATE_LOG_FORMAT=json floodgate --config config.yaml
+2026-04-01 12:00:01 INFO     [floodgate.zerohop] [ZEROHOP] topic=msh/US/2/e/LongFast/!a2e1a8c4 channel=LongFast encoding=e id=3827461829 from=!a2e1a8c4 to=!ffffffff hop_limit=3 hop_start=3
+2026-04-01 12:00:02 INFO     [floodgate.zerohop] [NOOP] topic=msh/US/2/e/LongFast/!b3c4d5e6 channel=LongFast encoding=e id=2019283746 from=!b3c4d5e6 to=!ffffffff hop_limit=0 hop_start=3
+2026-04-01 12:00:15 INFO     [floodgate.zerohop] [PASSTHRU] topic=msh/US/2/e/MyPrivate/!a2e1a8c4 channel=MyPrivate encoding=e id=1234567890 from=!a2e1a8c4 to=!ffffffff
+2026-04-01 12:01:01 INFO     [floodgate.exhook_server] [STATS] interval_s=60 zerohop=142 passthru=1 noop=0 skipped=1050 errors=0 total=1193
 ```
 
-Each log line is a JSON object with structured fields (`outcome`, `channel`, `packet_id`, `from_node`, `hop_from`, etc.) usable in LogQL:
+**JSON mode** (`log_format: json` or `FLOODGATE_LOG_FORMAT=json`):
+```json
+{"timestamp":"2026-04-01T12:00:01Z","level":"INFO","name":"floodgate.zerohop","message":"zerohop","event":"message","outcome":"zerohop","topic":"msh/US/2/e/LongFast/!a2e1a8c4","channel":"LongFast","encoding":"e","id":3827461829,"from":"!a2e1a8c4","to":"!ffffffff","hop_limit":3,"hop_start":3}
+```
+
+JSON output is optimized for Loki/Grafana: the `message` field is just the outcome tag, all data is in structured top-level fields. Example LogQL queries:
 
 ```
-{job="floodgate"} | json | outcome="zerohop"
-{job="floodgate"} | json | channel="LongFast"
+{container="floodgate"} | json | outcome="zerohop"
+{container="floodgate"} | json | channel="LongFast"
+{container="floodgate"} | json | from="!a2e1a8c4"
+sum by (outcome) (count_over_time({container="floodgate"} | json | event="message" [5m]))
 ```
 
 ### Kubernetes
@@ -273,9 +278,9 @@ pytest tests/ -q   # full suite including container smoke test (requires Docker)
 
 **Log output (INFO, text mode):**
 ```
-2026-04-01 14:23:47 INFO     [floodgate.zerohop] [ZEROHOP]  topic=msh/US/2/e/LongFast/!a2e1a8c4  channel=LongFast  encoding=e  hop 3→0  id=3827461829  from=!a2e1a8c4  to=^all
-2026-04-01 14:23:48 INFO     [floodgate.zerohop] [PASSTHRU] topic=msh/US/2/e/MyPrivate/!a2e1a8c4  channel=MyPrivate  encoding=e  id=1234567890  from=!a2e1a8c4  to=^all
-2026-04-01 14:24:47 INFO     [floodgate.exhook_server] Stats [last 60s]  zerohopped=142   passthru=3    noop=0    skipped=1050  errors=0    total=1195
+2026-04-01 14:23:47 INFO     [floodgate.zerohop] [ZEROHOP] topic=msh/US/2/e/LongFast/!a2e1a8c4 channel=LongFast encoding=e id=3827461829 from=!a2e1a8c4 to=!ffffffff hop_limit=3 hop_start=3
+2026-04-01 14:23:48 INFO     [floodgate.zerohop] [PASSTHRU] topic=msh/US/2/e/MyPrivate/!a2e1a8c4 channel=MyPrivate encoding=e id=1234567890 from=!a2e1a8c4 to=!ffffffff
+2026-04-01 14:24:47 INFO     [floodgate.exhook_server] [STATS] interval_s=60 zerohop=142 passthru=3 noop=0 skipped=1050 errors=0 total=1195
 ```
 
 ## Legal

--- a/config.yaml
+++ b/config.yaml
@@ -28,4 +28,8 @@ log_level: "INFO"
 
 # "text" (human-readable) or "json" (structured, for Loki/Grafana).
 # Override with FLOODGATE_LOG_FORMAT env var.
-log_format: "text"
+log_format: "json"
+
+# Log periodic stats summary (zerohop/passthru/noop counts).
+# Set false to disable stats log lines.
+stats_log: true

--- a/src/floodgate/config.py
+++ b/src/floodgate/config.py
@@ -32,6 +32,7 @@ DEFAULT_CONFIG = {
     "stats_interval_s": 60,
     "log_level": "INFO",
     "log_format": "text",   # "text" | "json"
+    "stats_log": True,
 }
 
 

--- a/src/floodgate/exhook_server.py
+++ b/src/floodgate/exhook_server.py
@@ -132,30 +132,29 @@ class HookProviderServicer:
 # Periodic stats reporter
 # ---------------------------------------------------------------------------
 
-def _stats_reporter(interval_s: int, stop_event: threading.Event):
+def _stats_reporter(interval_s: int, stop_event: threading.Event,
+                    stats_log: bool = True):
     """Log rolling stats every interval_s seconds (resets counters each cycle)."""
     while not stop_event.wait(timeout=interval_s):
         snap = packet_stats.reset()
+        if not stats_log:
+            continue
         if snap["total"] > 0:
             logger.info(
-                "Stats [last %ds]  zerohopped=%-4d  passthru=%-4d  noop=%-4d"
-                "  skipped=%-4d  errors=%-4d  total=%d",
-                interval_s,
-                snap["zerohopped"], snap["passthru"], snap["noop"],
-                snap["skipped"],    snap["errors"],   snap["total"],
+                "stats",
                 extra={
-                    "event":       "stats",
-                    "interval_s":  interval_s,
-                    "zerohopped":  snap["zerohopped"],
-                    "passthru":    snap["passthru"],
-                    "noop":        snap["noop"],
-                    "skipped":     snap["skipped"],
-                    "errors":      snap["errors"],
-                    "total":       snap["total"],
+                    "event":      "stats",
+                    "interval_s": interval_s,
+                    "zerohop":    snap["zerohop"],
+                    "passthru":   snap["passthru"],
+                    "noop":       snap["noop"],
+                    "skipped":    snap["skipped"],
+                    "errors":     snap["errors"],
+                    "total":      snap["total"],
                 },
             )
         else:
-            logger.debug("Stats [last %ds]  no meshtastic messages received", interval_s)
+            logger.debug("No meshtastic messages in last %ds", interval_s)
 
 
 # ---------------------------------------------------------------------------
@@ -220,10 +219,11 @@ def serve(config: dict):
     logger.info("Waiting for EMQX to connect and register ExHook...")
     _log_startup_policy(config)
 
+    stats_log = config.get("stats_log", True)
     stop_event   = threading.Event()
     stats_thread = threading.Thread(
         target=_stats_reporter,
-        args=(stats_interval, stop_event),
+        args=(stats_interval, stop_event, stats_log),
         daemon=True,
         name="stats-reporter",
     )

--- a/src/floodgate/log_setup.py
+++ b/src/floodgate/log_setup.py
@@ -2,6 +2,61 @@
 
 import logging
 
+# Fields rendered by StructuredTextFormatter, in display order.
+_MESSAGE_FIELDS = (
+    "topic", "channel", "encoding", "id", "from", "to",
+    "hop_limit", "hop_start", "relay", "via_mqtt",
+)
+_STATS_FIELDS = (
+    "interval_s", "zerohop", "passthru", "noop", "skipped", "errors", "total",
+)
+
+# Outcome tags → display labels for text mode
+_OUTCOME_TAGS = {
+    "zerohop": "[ZEROHOP]",
+    "passthru": "[PASSTHRU]",
+    "noop": "[NOOP]",
+    "warn": "[WARN]",
+}
+
+
+class StructuredTextFormatter(logging.Formatter):
+    """Renders structured extra={} fields as key=value pairs in text mode."""
+
+    def __init__(self):
+        super().__init__(
+            fmt="%(asctime)s %(levelname)-8s [%(name)s] %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+
+    def format(self, record):
+        event = getattr(record, "event", None)
+        if event == "message":
+            record.msg = self._format_message(record)
+            record.args = None
+        elif event == "stats":
+            record.msg = self._format_stats(record)
+            record.args = None
+        return super().format(record)
+
+    def _format_message(self, record):
+        outcome = getattr(record, "outcome", "")
+        tag = _OUTCOME_TAGS.get(outcome, f"[{outcome.upper()}]")
+        parts = [tag]
+        for key in _MESSAGE_FIELDS:
+            val = getattr(record, key, None)
+            if val is not None:
+                parts.append(f"{key}={val}")
+        return " ".join(parts)
+
+    def _format_stats(self, record):
+        parts = ["[STATS]"]
+        for key in _STATS_FIELDS:
+            val = getattr(record, key, None)
+            if val is not None:
+                parts.append(f"{key}={val}")
+        return " ".join(parts)
+
 
 def build_formatter(log_format: str) -> logging.Formatter:
     """Return a Formatter for the requested format ('text' or 'json')."""
@@ -16,10 +71,7 @@ def build_formatter(log_format: str) -> logging.Formatter:
             rename_fields={"levelname": "level", "asctime": "timestamp"},
             datefmt="%Y-%m-%dT%H:%M:%SZ",
         )
-    return logging.Formatter(
-        fmt="%(asctime)s %(levelname)-8s [%(name)s] %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
+    return StructuredTextFormatter()
 
 
 def configure_logging(level: int, log_format: str) -> None:

--- a/src/floodgate/zerohop.py
+++ b/src/floodgate/zerohop.py
@@ -33,11 +33,11 @@ def _load_protos():
 @dataclass
 class AntifloodStats:
     """Thread-safe counters for observability."""
-    zerohopped: int = 0
-    passthru:   int = 0
-    noop:       int = 0
-    skipped:    int = 0
-    errors:     int = 0
+    zerohop:  int = 0
+    passthru: int = 0
+    noop:     int = 0
+    skipped:  int = 0
+    errors:   int = 0
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
     def inc(self, counter: str):
@@ -46,31 +46,31 @@ class AntifloodStats:
 
     @property
     def total(self) -> int:
-        return self.zerohopped + self.passthru + self.noop + self.skipped + self.errors
+        return self.zerohop + self.passthru + self.noop + self.skipped + self.errors
 
     def snapshot(self) -> dict:
         with self._lock:
             return {
-                "zerohopped": self.zerohopped,
-                "passthru":   self.passthru,
-                "noop":       self.noop,
-                "skipped":    self.skipped,
-                "errors":     self.errors,
-                "total":      self.total,
+                "zerohop":  self.zerohop,
+                "passthru": self.passthru,
+                "noop":     self.noop,
+                "skipped":  self.skipped,
+                "errors":   self.errors,
+                "total":    self.total,
             }
 
     def reset(self) -> dict:
         """Return a snapshot then reset all counters to zero."""
         with self._lock:
             snap = {
-                "zerohopped": self.zerohopped,
-                "passthru":   self.passthru,
-                "noop":       self.noop,
-                "skipped":    self.skipped,
-                "errors":     self.errors,
-                "total":      self.total,
+                "zerohop":  self.zerohop,
+                "passthru": self.passthru,
+                "noop":     self.noop,
+                "skipped":  self.skipped,
+                "errors":   self.errors,
+                "total":    self.total,
             }
-            self.zerohopped = self.passthru = self.noop = self.skipped = self.errors = 0
+            self.zerohop = self.passthru = self.noop = self.skipped = self.errors = 0
             return snap
 
 
@@ -83,34 +83,10 @@ stats = AntifloodStats()
 # ---------------------------------------------------------------------------
 
 def _fmt_node(node_id: int | None) -> str:
-    """Format a full Meshtastic node ID for display."""
+    """Format a Meshtastic node ID as !hex."""
     if node_id is None:
         return "?"
-    if node_id == 0xFFFFFFFF:
-        return "^all"
     return f"!{node_id:08x}"
-
-
-def _fmt_meta(meta: dict) -> str:
-    """Format packet metadata fields for a log line."""
-    parts = []
-    if meta.get("packet_id"):
-        parts.append(f"id={meta['packet_id']}")
-    if meta.get("sender") is not None:
-        parts.append(f"from={_fmt_node(meta['sender'])}")
-    if meta.get("destination") is not None:
-        parts.append(f"to={_fmt_node(meta['destination'])}")
-    if meta.get("hop_start"):
-        parts.append(f"hop_start={meta['hop_start']}")
-    if meta.get("via_mqtt"):
-        parts.append("via_mqtt=T")
-    # relay_node is only the low byte of the relaying node's ID
-    relay = meta.get("relay_node")
-    if relay:
-        parts.append(f"relay={relay & 0xFF:02x}")
-    if meta.get("next_hop"):
-        parts.append(f"next_hop={_fmt_node(meta['next_hop'])}")
-    return "  ".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -306,14 +282,8 @@ def zerohop_json(payload: bytes) -> tuple[bytes | None, int | None, dict]:
 def process_message(topic: str, payload: bytes, config: dict) -> bytes | None:
     """Process one MQTT message; return modified payload or None (pass-through).
 
-    Non-packet msh/ topics (map reports, stat topics, etc.) are silently
-    ignored and counted under 'skipped' in stats.
-
-    Processed packet outcomes are logged at INFO level:
-      [ZEROHOP]   modified, subscribers receive hop_limit=0
-      [PASSTHRU]  channel exempted by policy, subscribers receive original
-      [NOOP]      hop_limit was already 0, no change
-      [WARN]      payload could not be parsed — original forwarded unchanged
+    Outcomes logged at INFO: zerohop, passthru, noop, warn.
+    Non-packet topics silently skipped (counted in stats).
     """
     try:
         return _process_message_inner(topic, payload, config)
@@ -342,18 +312,21 @@ def _process_message_inner(topic: str, payload: bytes, config: dict) -> bytes | 
     if not should_zerohop(config, channel):
         stats.inc("passthru")
         meta = _peek_meta(encoding, payload)
-        pkt_fields = _fmt_meta(meta)
+        relay = meta.get("relay_node")
         logger.info(
-            "[PASSTHRU] topic=%s  channel=%s%s",
-            topic, channel, f"  {pkt_fields}" if pkt_fields else "",
+            "passthru",
             extra={
-                "outcome":    "passthru",
-                "topic":      topic,
-                "channel":    channel,
-                "encoding":   encoding,
-                "packet_id":  meta.get("packet_id"),
-                "from_node":  _fmt_node(meta.get("sender")),
-                "to_node":    _fmt_node(meta.get("destination")),
+                "event":     "message",
+                "outcome":   "passthru",
+                "topic":     topic,
+                "channel":   channel,
+                "encoding":  encoding,
+                "id":        meta.get("packet_id"),
+                "from":      _fmt_node(meta.get("sender")),
+                "to":        _fmt_node(meta.get("destination")),
+                "hop_start": meta.get("hop_start"),
+                "relay":     f"{relay & 0xFF:02x}" if relay else None,
+                "via_mqtt":  meta.get("via_mqtt"),
             },
         )
         return None
@@ -363,58 +336,60 @@ def _process_message_inner(topic: str, payload: bytes, config: dict) -> bytes | 
     else:
         modified, old_hop, meta = zerohop_protobuf(payload)
 
-    pkt_fields = _fmt_meta(meta)
-
     if modified is None and old_hop is None:
         stats.inc("errors")
         logger.warning(
-            "[WARN]     topic=%s  channel=%s  could not parse %d-byte payload",
-            topic, channel, len(payload),
+            "warn",
             extra={
-                "outcome":   "warn",
-                "topic":     topic,
-                "channel":   channel,
-                "encoding":  encoding,
-                "bytes":     len(payload),
+                "event":    "message",
+                "outcome":  "warn",
+                "topic":    topic,
+                "channel":  channel,
+                "encoding": encoding,
+                "bytes":    len(payload),
             },
         )
         return None
 
     if old_hop == 0:
         stats.inc("noop")
+        relay = meta.get("relay_node")
         logger.info(
-            "[NOOP]     topic=%s  channel=%s  hop_limit already 0%s",
-            topic, channel,
-            ("  " + pkt_fields) if pkt_fields else "",
+            "noop",
             extra={
-                "outcome":    "noop",
-                "topic":      topic,
-                "channel":    channel,
-                "encoding":   encoding,
-                "packet_id":  meta.get("packet_id"),
-                "from_node":  _fmt_node(meta.get("sender")),
-                "to_node":    _fmt_node(meta.get("destination")),
-                "hop_from":   0,
-                "hop_to":     0,
+                "event":     "message",
+                "outcome":   "noop",
+                "topic":     topic,
+                "channel":   channel,
+                "encoding":  encoding,
+                "id":        meta.get("packet_id"),
+                "from":      _fmt_node(meta.get("sender")),
+                "to":        _fmt_node(meta.get("destination")),
+                "hop_limit": 0,
+                "hop_start": meta.get("hop_start"),
+                "relay":     f"{relay & 0xFF:02x}" if relay else None,
+                "via_mqtt":  meta.get("via_mqtt"),
             },
         )
         return None
 
-    stats.inc("zerohopped")
+    stats.inc("zerohop")
+    relay = meta.get("relay_node")
     logger.info(
-        "[ZEROHOP]  topic=%s  channel=%s  encoding=%s  hop %d\u21920%s",
-        topic, channel, encoding, old_hop,
-        ("  " + pkt_fields) if pkt_fields else "",
+        "zerohop",
         extra={
-            "outcome":    "zerohop",
-            "topic":      topic,
-            "channel":    channel,
-            "encoding":   encoding,
-            "packet_id":  meta.get("packet_id"),
-            "from_node":  _fmt_node(meta.get("sender")),
-            "to_node":    _fmt_node(meta.get("destination")),
-            "hop_from":   old_hop,
-            "hop_to":     0,
+            "event":     "message",
+            "outcome":   "zerohop",
+            "topic":     topic,
+            "channel":   channel,
+            "encoding":  encoding,
+            "id":        meta.get("packet_id"),
+            "from":      _fmt_node(meta.get("sender")),
+            "to":        _fmt_node(meta.get("destination")),
+            "hop_limit": old_hop,
+            "hop_start": meta.get("hop_start"),
+            "relay":     f"{relay & 0xFF:02x}" if relay else None,
+            "via_mqtt":  meta.get("via_mqtt"),
         },
     )
     return modified

--- a/tests/test_container_smoke.py
+++ b/tests/test_container_smoke.py
@@ -112,7 +112,7 @@ class TestContainerSmoke:
         _, body = _wait_for_health(f"http://localhost:{HEALTH_PORT}/health")
         data = json.loads(body)
         stats = data["stats"]
-        for key in ("zerohopped", "passthru", "noop", "skipped", "errors", "total"):
+        for key in ("zerohop", "passthru", "noop", "skipped", "errors", "total"):
             assert key in stats, f"missing stats key: {key}"
 
     def test_unknown_path_returns_404(self, running_container):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -77,13 +77,13 @@ class TestHealthEndpoint:
             _, body = _get(f"{base}/health")
             data = json.loads(body)
             stats = data["stats"]
-            for key in ("zerohopped", "passthru", "noop", "skipped", "errors", "total"):
+            for key in ("zerohop", "passthru", "noop", "skipped", "errors", "total"):
                 assert key in stats, f"missing key: {key}"
         finally:
             server.shutdown()
 
     def test_health_stats_reflect_counters(self):
-        packet_stats.zerohopped = 5
+        packet_stats.zerohop = 5
         packet_stats.passthru = 2
         packet_stats.noop = 1
 
@@ -91,7 +91,7 @@ class TestHealthEndpoint:
         try:
             _, body = _get(f"{base}/health")
             stats = json.loads(body)["stats"]
-            assert stats["zerohopped"] == 5
+            assert stats["zerohop"] == 5
             assert stats["passthru"] == 2
             assert stats["noop"] == 1
             assert stats["total"] == 8

--- a/tests/test_log_setup.py
+++ b/tests/test_log_setup.py
@@ -3,18 +3,14 @@
 import json
 import logging
 
-from floodgate.log_setup import build_formatter
+from floodgate.log_setup import StructuredTextFormatter, build_formatter
 
 
 class TestBuildFormatter:
 
-    def test_text_formatter_is_standard(self):
+    def test_text_formatter_is_structured(self):
         fmt = build_formatter("text")
-        assert isinstance(fmt, logging.Formatter)
-        record = logging.LogRecord("test", logging.INFO, "", 0, "hello", (), None)
-        output = fmt.format(record)
-        assert "hello" in output
-        assert "INFO" in output
+        assert isinstance(fmt, StructuredTextFormatter)
 
     def test_json_formatter_emits_valid_json(self):
         fmt = build_formatter("json")
@@ -23,21 +19,32 @@ class TestBuildFormatter:
         data = json.loads(output)
         assert data["message"] == "hello"
         assert "level" in data
-        assert "levelname" not in data   # must be renamed to "level"
+        assert "levelname" not in data
 
     def test_json_formatter_includes_extra_fields(self):
         fmt = build_formatter("json")
         record = logging.LogRecord("test", logging.INFO, "", 0, "zerohop", (), None)
-        record.outcome  = "zerohop"
-        record.channel  = "LongFast"
-        record.hop_from = 3
-        record.hop_to   = 0
+        record.event = "message"
+        record.outcome = "zerohop"
+        record.channel = "LongFast"
+        record.hop_limit = 3
+        record.hop_start = 5
         output = fmt.format(record)
         data = json.loads(output)
-        assert data["outcome"]  == "zerohop"
-        assert data["channel"]  == "LongFast"
-        assert data["hop_from"] == 3
-        assert data["hop_to"]   == 0
+        assert data["outcome"] == "zerohop"
+        assert data["channel"] == "LongFast"
+        assert data["hop_limit"] == 3
+        assert data["hop_start"] == 5
+
+    def test_json_message_is_just_outcome_tag(self):
+        fmt = build_formatter("json")
+        record = logging.LogRecord("test", logging.INFO, "", 0, "zerohop", (), None)
+        record.event = "message"
+        record.outcome = "zerohop"
+        record.topic = "msh/US/2/e/LongFast/!1234"
+        record.channel = "LongFast"
+        data = json.loads(fmt.format(record))
+        assert data["message"] == "zerohop"
 
     def test_json_formatter_level_value(self):
         fmt = build_formatter("json")
@@ -50,4 +57,50 @@ class TestBuildFormatter:
         record = logging.LogRecord("test", logging.INFO, "", 0, "ts", (), None)
         data = json.loads(fmt.format(record))
         assert "timestamp" in data
-        assert "asctime" not in data     # must be renamed to "timestamp"
+        assert "asctime" not in data
+
+
+class TestStructuredTextFormatter:
+
+    def _format(self, msg, **extras):
+        fmt = StructuredTextFormatter()
+        record = logging.LogRecord("test", logging.INFO, "", 0, msg, (), None)
+        for k, v in extras.items():
+            setattr(record, k, v)
+        return fmt.format(record)
+
+    def test_message_event_renders_outcome_tag(self):
+        output = self._format(
+            "zerohop", event="message", outcome="zerohop",
+            topic="msh/US/2/e/LongFast/!1234", channel="LongFast",
+            encoding="e", hop_limit=3, hop_start=3,
+        )
+        assert "[ZEROHOP]" in output
+        assert "topic=msh/US/2/e/LongFast/!1234" in output
+        assert "channel=LongFast" in output
+        assert "hop_limit=3" in output
+        assert "hop_start=3" in output
+
+    def test_stats_event_renders_stats_tag(self):
+        output = self._format(
+            "stats", event="stats", interval_s=60,
+            zerohop=5, passthru=1, noop=0, skipped=10, errors=0, total=16,
+        )
+        assert "[STATS]" in output
+        assert "zerohop=5" in output
+        assert "total=16" in output
+
+    def test_plain_message_passes_through(self):
+        output = self._format("ExHook gRPC server listening on port 9000")
+        assert "ExHook gRPC server listening on port 9000" in output
+        assert "[ZEROHOP]" not in output
+        assert "[STATS]" not in output
+
+    def test_none_fields_omitted(self):
+        output = self._format(
+            "passthru", event="message", outcome="passthru",
+            topic="msh/US/2/e/LongFast/!1234", channel="LongFast",
+            encoding="e", relay=None, via_mqtt=None,
+        )
+        assert "relay=" not in output
+        assert "via_mqtt=" not in output

--- a/tests/test_zerohop.py
+++ b/tests/test_zerohop.py
@@ -263,4 +263,6 @@ class TestPeekMeta:
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
             result = process_message("msh/US/2/json/LongFast/!aabbccdd", payload, config)
         assert result is None
-        assert "99999" in caplog.text
+        rec = caplog.records[-1]
+        assert getattr(rec, "id") == 99999
+        assert getattr(rec, "outcome") == "passthru"


### PR DESCRIPTION
## Summary

- JSON `message` field now contains only the outcome tag (`zerohop`, `passthru`, etc.) — no redundant data duplication
- Rename structured fields to match [Meshtastic protobuf terminology](https://meshtastic.org/docs/overview/mesh-algo/): `hop_limit`, `hop_start`, `id`, `from`, `to`
- Add `StructuredTextFormatter` for consistent `key=value` text output matching JSON field names
- Standardize stats counter naming (`zerohopped` → `zerohop`) across stats, health endpoint, and logs
- Replace non-standard `^all` broadcast format with `!ffffffff`
- Add `stats_log` config option to toggle periodic stats output
- Add `hop_start`, `relay`, `via_mqtt` fields to per-message structured output

## Test plan

- [ ] `pytest tests/ --ignore=tests/test_container_smoke.py -q` — 71 tests pass
- [ ] Verify JSON output: each line is valid JSON, `message` is just the outcome tag
- [ ] Verify text output: `[ZEROHOP]` / `[STATS]` tags with ordered `key=value` pairs
- [ ] Verify LogQL queries work: `| json | outcome="zerohop"`, `| json | channel="LongFast"`
- [ ] Verify health endpoint returns `zerohop` (not `zerohopped`) in stats keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)