### PR TITLE
docs: document release workflow and branching strategy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,13 +50,14 @@ docker compose up --build
 
 After startup, register the ExHook in EMQX (see docker-compose.yaml header for the curl command).
 
-## Branching & Commit Strategy
+## Branching & Release Strategy
 
 - `main` — stable, tagged releases only
 - `feat/<name>`, `fix/<name>`, `docs/<name>`, `chore/<name>` — branch from main, PR back to main
 - Commits: conventional format — `feat:`, `fix:`, `docs:`, `test:`, `chore:`
-- PRs: squash-merge to main
-- Releases: semantic versioning (`v0.1.0`, ...), GitHub release + git tag
+- PRs: squash-merge to main; delete branch after merge
+- Releases: `git tag vX.Y.Z && git push origin vX.Y.Z` triggers release + Docker publish to GHCR
+- See [CONTRIBUTING.md](CONTRIBUTING.md) for full release workflow details
 
 ## Key Config Options
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,9 +44,46 @@ ruff check src/ tests/
 
 Conventional commits: `feat:`, `fix:`, `docs:`, `test:`, `chore:`
 
-## Releases
+## Branching strategy
 
-Maintainers tag releases on `main` as `vMAJOR.MINOR.PATCH`. The release workflow runs lint, the full test matrix, and the container smoke test before creating a GitHub release automatically.
+- `main` — stable, tagged releases only
+- Feature branches: `feat/<name>`, `fix/<name>`, `docs/<name>`, `chore/<name>`
+- Branch from `main`, PR back to `main`, squash-merge
+- Delete feature branches after merge (GitHub auto-deletes remote; clean local with `git branch -d`)
+
+## Release workflow
+
+Releases use semantic versioning (`v0.2.1`, `v1.0.0`, etc.).
+
+### Steps
+
+1. Merge PR(s) to `main`
+2. Tag the release:
+   ```bash
+   git checkout main && git pull
+   git tag v0.X.Y
+   git push origin v0.X.Y
+   ```
+3. Two workflows trigger automatically on tag push:
+   - **Release** (`release.yml`): lint → test → smoke → creates a GitHub Release with auto-generated notes
+   - **Docker** (`docker-publish.yml`): builds multi-arch image (amd64 + arm64) and pushes to `ghcr.io/eric-becker/floodgate:<version>`
+4. Update downstream deployments to reference the new image tag
+
+### What gets published
+
+| Trigger | Image tags pushed to GHCR |
+|---------|---------------------------|
+| Push to `main` | `latest` |
+| Tag `v0.2.1` | `0.2.1`, `0.2`, `latest` |
+| PR (build-only) | `pr-<number>` (not pushed) |
+
+### Version bumping
+
+- Patch (`v0.2.0` → `v0.2.1`): bug fixes, logging changes, config additions
+- Minor (`v0.2.1` → `v0.3.0`): new features, behavior changes
+- Major (`v0.3.0` → `v1.0.0`): breaking config or API changes
+
+The version in `pyproject.toml` is the Python package version and does not need to match the Docker image tag — the git tag is the source of truth for releases.
 
 ## Protobuf compatibility
 


### PR DESCRIPTION
## Summary

- Add release workflow details to CONTRIBUTING.md: tag-triggered builds, GHCR image publishing, version bumping guidance, branch cleanup
- Update CLAUDE.md branching section to reference CONTRIBUTING.md and include branch cleanup + release commands

## Test plan

- [ ] Docs only — no code changes
- [ ] CI should pass (lint, tests, smoke, manifests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)