### PR TITLE
fix: health endpoint shows cumulative lifetime stats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Or with Docker Compose (includes EMQX):
 docker compose up --build
 ```
 
-After startup, register the ExHook in EMQX (see docker-compose.yaml header for the curl command).
+After startup, register the ExHook in EMQX (see README Deployment section for the curl commands).
 
 ## Branching & Commit Strategy
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ The production container image runs as `nobody` (UID 65534) with a read-only fil
 
 ### Health endpoint
 
-floodgate exposes a health check at `GET /health` on port 8080 (configurable via `health_port`):
+floodgate exposes a health check at `GET /health` on port 8080 (configurable via `health_port`). Stats are cumulative lifetime counters that persist across stats reporter intervals:
 
 ```bash
 curl -s http://localhost:8080/health | jq .

--- a/config.yaml
+++ b/config.yaml
@@ -28,7 +28,7 @@ log_level: "INFO"
 
 # "text" (human-readable) or "json" (structured, for Loki/Grafana).
 # Override with FLOODGATE_LOG_FORMAT env var.
-log_format: "json"
+log_format: "text"
 
 # Log periodic stats summary (zerohop/passthru/noop counts).
 # Set false to disable stats log lines.

--- a/src/floodgate/zerohop.py
+++ b/src/floodgate/zerohop.py
@@ -30,46 +30,48 @@ def _load_protos():
 # Statistics
 # ---------------------------------------------------------------------------
 
+_COUNTER_NAMES = ("zerohop", "passthru", "noop", "skipped", "errors")
+
+
 @dataclass
 class AntifloodStats:
-    """Thread-safe counters for observability."""
+    """Thread-safe packet counters.
+
+    Two sets: rolling window (reset each stats interval) and lifetime
+    (cumulative, never reset). The stats reporter reads rolling via reset();
+    the health endpoint reads lifetime via snapshot().
+    """
+    # Rolling window — reset by stats reporter each interval
     zerohop:  int = 0
     passthru: int = 0
     noop:     int = 0
     skipped:  int = 0
     errors:   int = 0
+    # Lifetime — never reset
+    _lifetime: dict = field(default_factory=lambda: {k: 0 for k in _COUNTER_NAMES})
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
     def inc(self, counter: str):
         with self._lock:
             setattr(self, counter, getattr(self, counter) + 1)
+            self._lifetime[counter] += 1
 
     @property
     def total(self) -> int:
         return self.zerohop + self.passthru + self.noop + self.skipped + self.errors
 
     def snapshot(self) -> dict:
+        """Return lifetime cumulative counters (for health endpoint)."""
         with self._lock:
-            return {
-                "zerohop":  self.zerohop,
-                "passthru": self.passthru,
-                "noop":     self.noop,
-                "skipped":  self.skipped,
-                "errors":   self.errors,
-                "total":    self.total,
-            }
+            snap = dict(self._lifetime)
+            snap["total"] = sum(self._lifetime.values())
+            return snap
 
     def reset(self) -> dict:
-        """Return a snapshot then reset all counters to zero."""
+        """Return rolling window snapshot then reset rolling counters to zero."""
         with self._lock:
-            snap = {
-                "zerohop":  self.zerohop,
-                "passthru": self.passthru,
-                "noop":     self.noop,
-                "skipped":  self.skipped,
-                "errors":   self.errors,
-                "total":    self.total,
-            }
+            snap = {k: getattr(self, k) for k in _COUNTER_NAMES}
+            snap["total"] = self.total
             self.zerohop = self.passthru = self.noop = self.skipped = self.errors = 0
             return snap
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -38,13 +38,15 @@ def _get(url):
 class TestHealthEndpoint:
 
     def setup_method(self):
-        # Reset stats counters before each test so they don't bleed across tests
+        # Reset both rolling and lifetime counters before each test
         with packet_stats._lock:
-            packet_stats.zerohopped = 0
+            packet_stats.zerohop = 0
             packet_stats.passthru = 0
             packet_stats.noop = 0
             packet_stats.skipped = 0
             packet_stats.errors = 0
+            for k in packet_stats._lifetime:
+                packet_stats._lifetime[k] = 0
 
     def test_health_returns_200(self):
         server, base = _start_test_server()
@@ -82,10 +84,12 @@ class TestHealthEndpoint:
         finally:
             server.shutdown()
 
-    def test_health_stats_reflect_counters(self):
-        packet_stats.zerohop = 5
-        packet_stats.passthru = 2
-        packet_stats.noop = 1
+    def test_health_stats_reflect_lifetime_counters(self):
+        for _ in range(5):
+            packet_stats.inc("zerohop")
+        for _ in range(2):
+            packet_stats.inc("passthru")
+        packet_stats.inc("noop")
 
         server, base = _start_test_server()
         try:
@@ -95,6 +99,25 @@ class TestHealthEndpoint:
             assert stats["passthru"] == 2
             assert stats["noop"] == 1
             assert stats["total"] == 8
+        finally:
+            server.shutdown()
+
+    def test_health_stats_survive_reset(self):
+        """Lifetime counters persist after stats reporter reset()."""
+        for _ in range(3):
+            packet_stats.inc("zerohop")
+        packet_stats.inc("passthru")
+
+        # Simulate stats reporter draining the rolling window
+        packet_stats.reset()
+
+        server, base = _start_test_server()
+        try:
+            _, body = _get(f"{base}/health")
+            stats = json.loads(body)["stats"]
+            assert stats["zerohop"] == 3
+            assert stats["passthru"] == 1
+            assert stats["total"] == 4
         finally:
             server.shutdown()
 


### PR DESCRIPTION
## Summary

- Health endpoint `/health` now returns cumulative lifetime counters instead of rolling window counters that get zeroed every 60s by the stats reporter
- Add `test_health_stats_survive_reset` test verifying lifetime counters persist across `reset()` calls
- Fix stale CLAUDE.md reference to removed docker-compose comments
- Reset repo config.yaml `log_format` default to `text` (JSON is for production deployments, not the default dev config)

Fixes #17

## Test plan

- [ ] 72 unit tests pass
- [ ] `curl /health` returns cumulative stats that increase over time
- [ ] Stats log lines still show rolling 60s window counts
- [ ] Container smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)