### PR TITLE
fix: ExHook failure policy, dependency ordering, and k8s rolling updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,15 @@ curl -X POST http://localhost:18083/api/v5/exhooks \
   -d '{
     "name": "floodgate",
     "url": "http://YOUR_HOST_IP:9000",
-    "auto_reconnect": "60s",
-    "failed_action": "ignore"
+    "auto_reconnect": "5s",
+    "failed_action": "deny"
   }'
 ```
 
 If floodgate is on the same Docker network as EMQX, use the container name instead of an IP:
 `"url": "http://floodgate:9000"`
+
+See [ExHook failure policy](#exhook-failure-policy) for why `deny` is recommended.
 
 Verify registration in the EMQX dashboard under **Management → ExHook** or:
 
@@ -97,7 +99,7 @@ After startup, register the ExHook per the [Deployment](#deployment) instruction
 
 ### Kubernetes
 
-See [k8s/](k8s/) — Deployment, Service, and ConfigMap. Register the ExHook at `http://floodgate:9000` after applying.
+See [k8s/](k8s/) — Deployment, Service, and ConfigMap. The Deployment uses a rolling update strategy for zero-downtime upgrades. Register the ExHook at `http://floodgate:9000` after applying.
 
 ### Source install
 
@@ -161,6 +163,21 @@ channel_policy: "whitelist"
 channel_whitelist:
   - "MyPrivateChannel"
 ```
+
+### ExHook failure policy
+
+EMQX's `failed_action` controls what happens to MQTT messages when floodgate is unreachable (crash, restart, upgrade):
+
+| `failed_action` | Floodgate down | Trade-off |
+|-----------------|----------------|-----------|
+| **`deny`** (recommended) | Messages dropped — not delivered to subscribers | Mesh protected, brief MQTT gap |
+| `ignore` | Messages delivered at full `hop_limit` | MQTT uninterrupted, mesh floods |
+
+**We recommend `deny`.** Dropped MQTT messages are a brief blind spot for subscribers; uncontrolled mesh flooding is real radio damage affecting every node in range. With `restart: unless-stopped` and `auto_reconnect: 5s`, the gap is typically under 20 seconds.
+
+**Startup ordering:** In Docker Compose, EMQX should `depends_on` floodgate (not the other way around). Floodgate is a gRPC server — it starts first, listens on port 9000, and waits. EMQX connects to it after boot. See [docker-compose.yaml](docker-compose.yaml) for the reference configuration.
+
+**Kubernetes** handles this differently: the Deployment uses a rolling update strategy (`maxUnavailable: 0, maxSurge: 1`) so the new pod starts and passes its readiness probe before the old pod is terminated. EMQX reconnects to the new pod via the Service — zero-downtime upgrades with no message gap.
 
 ## Security
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   emqx:
-    image: emqx/emqx:5.8.7
+    image: emqx/emqx:6.1.1
     ports:
       - "1883:1883"     # MQTT
       - "18083:18083"   # Dashboard / REST API
@@ -8,17 +8,24 @@ services:
       EMQX_NAME: "emqx"
     volumes:
       - emqx-data:/opt/emqx/data
+    depends_on:
+      floodgate:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "/opt/emqx/bin/emqx", "ctl", "status"]
+      interval: 5s
+      timeout: 25s
+      retries: 5
 
   floodgate:
     build: .
+    restart: unless-stopped
     ports:
       - "8080:8080"     # Health check / stats
     environment:
       FLOODGATE_CONFIG: /app/config.yaml
     volumes:
       - ./config.yaml:/app/config.yaml:ro
-    depends_on:
-      - emqx
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]
       interval: 30s

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -6,6 +6,11 @@ metadata:
     app: floodgate
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: floodgate


### PR DESCRIPTION
## Summary

- Change recommended `failed_action` from `ignore` to `deny` — drop messages rather than flood the mesh when floodgate is unreachable
- Reverse Docker Compose dependency: EMQX `depends_on` floodgate since floodgate is the gRPC server that should start first
- Reduce `auto_reconnect` from `60s` to `5s` to minimize the deny window during restarts
- Update `docker-compose.yaml`: EMQX `5.8.7` → `6.1.1`, add `restart: unless-stopped` to floodgate
- Add rolling update strategy to k8s Deployment (`maxUnavailable: 0`, `maxSurge: 1`) for zero-downtime upgrades
- Add **ExHook failure policy** section to README explaining `deny` vs `ignore` trade-offs and deployment ordering rationale

Addresses #19

## Test plan

- [ ] Unit tests pass (71 tests)
- [ ] k8s manifest validation passes (kubeconform in CI)
- [ ] `docker compose up --build` starts floodgate first, then EMQX
- [ ] README ExHook failure policy section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)