### PR TITLE
test: replace FL-specific test topics with generic examples

### DIFF
--- a/tests/test_zerohop.py
+++ b/tests/test_zerohop.py
@@ -35,26 +35,26 @@ class TestParseMetastasticTopic:
 
     def test_deep_topic_three_prefix_parts(self):
         # msh/{country}/{region}/2/e/LongFast/!nodeId — 3-part prefix
-        assert parse_meshtastic_topic("msh/US/FL/2/e/LongFast/!16cec9ac") == ("LongFast", "e")
+        assert parse_meshtastic_topic("msh/US/CA/2/e/LongFast/!16cec9ac") == ("LongFast", "e")
 
     def test_deep_topic_four_prefix_parts(self):
         # msh/{country}/{region}/{area}/2/e/LongFast/!nodeId — 4-part prefix
-        assert parse_meshtastic_topic("msh/US/FL/LWS/2/e/LongFast/!087a5a9c") == ("LongFast", "e")
+        assert parse_meshtastic_topic("msh/US/CA/BAY/2/e/LongFast/!087a5a9c") == ("LongFast", "e")
 
     def test_json_encoding_deep(self):
-        assert parse_meshtastic_topic("msh/US/FL/2/json/LongFast/!deadbeef") == ("LongFast", "json")
+        assert parse_meshtastic_topic("msh/US/CA/2/json/LongFast/!deadbeef") == ("LongFast", "json")
 
     def test_stat_topic_not_a_packet(self):
-        # Status topics like msh/US/FL don't end with !nodeId
-        assert parse_meshtastic_topic("msh/US/FL") is None
+        # Status topics without !nodeId suffix
+        assert parse_meshtastic_topic("msh/US/CA") is None
 
     def test_no_nodeid_suffix(self):
         # msh/ prefix but no !nodeId at the end
-        assert parse_meshtastic_topic("msh/US/FL/stat/somenode") is None
+        assert parse_meshtastic_topic("msh/US/CA/stat/somenode") is None
 
     def test_map_report_topic(self):
         # Map report published directly to region root — not a packet
-        assert parse_meshtastic_topic("msh/US/FL/map") is None
+        assert parse_meshtastic_topic("msh/US/CA/map") is None
 
     def test_unknown_encoding_returns_none(self):
         # Unknown encoding segment
@@ -142,29 +142,28 @@ class TestProcessMessage:
         assert process_message("other/topic", b"data", config) is None
 
     def test_msh_status_topic_silently_skipped(self):
-        # msh/US/FL (no !nodeId) — map report topic, must be silently ignored
         config = self._config()
-        assert process_message("msh/US/FL", b"data", config) is None
+        assert process_message("msh/US/CA", b"data", config) is None
 
     def test_whitelist_empty_zerohops_proto(self):
         config = self._config(policy="whitelist")
         with patch("floodgate.zerohop.zerohop_protobuf") as mock_zh:
             mock_zh.return_value = (b"modified", 3, {})
-            result = process_message("msh/US/FL/2/e/LongFast/!1234", b"proto", config)
+            result = process_message("msh/US/CA/2/e/LongFast/!1234", b"proto", config)
         assert result == b"modified"
 
     def test_whitelist_empty_zerohops_json(self):
         config = self._config(policy="whitelist")
         with patch("floodgate.zerohop.zerohop_json") as mock_zh:
             mock_zh.return_value = (b'{"hop_limit":0}', 3, {})
-            result = process_message("msh/US/FL/2/json/LongFast/!1234", b"json", config)
+            result = process_message("msh/US/CA/2/json/LongFast/!1234", b"json", config)
         assert result == b'{"hop_limit":0}'
 
     def test_whitelist_empty_zerohops_deep_topic(self):
         config = self._config(policy="whitelist")
         with patch("floodgate.zerohop.zerohop_protobuf") as mock_zh:
             mock_zh.return_value = (b"modified", 3, {})
-            result = process_message("msh/US/FL/LWS/2/e/LongFast/!16cec9ac", b"proto", config)
+            result = process_message("msh/US/CA/BAY/2/e/LongFast/!16cec9ac", b"proto", config)
         assert result == b"modified"
 
     def test_whitelist_bypasses_listed_channel(self):


### PR DESCRIPTION
## Summary

- Replace `msh/US/FL` with `msh/US/CA` and `LWS` with `BAY` in test topics
- The project is region-agnostic; tests should not imply a specific deployment

## Test plan

- [ ] 71 unit tests pass — test-only change, no code or docs modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)