### PR TITLE
docs: document skipped outcome in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Each message produces one outcome:
 | `noop` | Channel matched policy, already `hop_limit=0` |
 | `passthru` | Channel exempt by policy — unchanged |
 | `warn` | Payload parse failure — unchanged |
+| `skipped` | Non-packet topic (map report, stat, etc.) — silently ignored |
 
 ## Deployment
 


### PR DESCRIPTION
## Summary

- Add `skipped` to the outcomes table in README — non-packet topics (map reports, stat topics, etc.) that match `msh/#` but aren't processable packets

## Test plan

- [ ] Docs only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)