### PR TITLE
chore: add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ protobufs/*
 
 # Ansible collections / roles (may be installed locally when running playbooks from this dir)
 .ansible/
+
+# Claude Code local settings
+.claude/


### PR DESCRIPTION
## Summary

- Add `.claude/` to `.gitignore` — local Claude Code settings should not be committed

## Test plan

- [ ] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)