### PR TITLE
docs: audit documentation accuracy + add local-only paths note

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ protobufs/*
 
 # Claude Code local settings
 .claude/
+
+# Claude Code planning artifacts (created by superpowers writing-plans skill)
+docs/superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,3 +81,15 @@ When making code changes, **always update in the same PR**:
 - `CONTRIBUTING.md` — if CI jobs, test tiers, or branch strategy changes
 
 Do not open a PR until README and tests reflect the code changes being merged.
+
+## Local-only paths (never commit)
+
+These paths exist in working trees but are gitignored. Never stage them:
+
+- `.claude/` — local Claude Code settings
+- `docs/superpowers/` — planning artifacts written by Claude's superpowers skills
+- `.venv/`, `__pycache__/`, `.pytest_cache/`, `.ruff_cache/`, `coverage*` — Python build/test artefacts
+- `generated/` — Python protobuf stubs (built by `scripts/generate_protos.sh`)
+- `protobufs/meshtastic/` — upstream Meshtastic protobufs (downloaded by `scripts/download_protobufs.sh`); only `protobufs/.gitkeep` and `protobufs/README.md` are tracked
+
+Before starting work on a branch, `git fetch origin && git rebase origin/main` to pick up any landed changes to `.gitignore` or shared workflows.

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Per-message outcomes are logged at **INFO** — no special flags required. Field
 
 **JSON mode** (`log_format: json` or `FLOODGATE_LOG_FORMAT=json`):
 ```json
-{"timestamp":"2026-04-01T12:00:01Z","level":"INFO","name":"floodgate.zerohop","message":"zerohop","event":"message","outcome":"zerohop","topic":"msh/US/2/e/LongFast/!a2e1a8c4","channel":"LongFast","encoding":"e","id":3827461829,"from":"!a2e1a8c4","to":"!ffffffff","hop_limit":3,"hop_start":3}
+{"timestamp":"2026-04-01T12:00:01Z","level":"INFO","name":"floodgate.zerohop","message":"zerohop","event":"message","outcome":"zerohop","topic":"msh/US/2/e/LongFast/!a2e1a8c4","channel":"LongFast","encoding":"e","id":3827461829,"from":"!a2e1a8c4","to":"!ffffffff","hop_limit":3,"hop_start":3,"relay":null,"via_mqtt":null}
 ```
 
 JSON output is optimized for Loki/Grafana: the `message` field is just the outcome tag, all data is in structured top-level fields. Example LogQL queries:

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -21,3 +21,4 @@ data:
     stats_interval_s: 60
     log_level: "INFO"
     log_format: "text"
+    stats_log: true


### PR DESCRIPTION
## Summary

Two small changes:

1. **Doc audit** (closes #30) — verified every config option, log example, LogQL query, and k8s docs item against the actual code.

   Two real findings fixed:
   - `k8s/configmap.yaml` was missing the `stats_log: true` key that exists in `DEFAULT_CONFIG` and `config.yaml`.
   - The README's JSON log example was missing \`\"relay\":null,\"via_mqtt\":null\`. The formatter always emits these (verified against live `build_formatter(\"json\")` output) because the message-event \`extra={}\` always sets them and python-json-logger renders \`None\` as JSON \`null\`.

   Everything else (health endpoint cumulative-counter docs, ExHook failure policy, k8s rolling update strategy, config defaults, log field order, LogQL queries) was verified accurate — no other changes needed.

2. **Repo hygiene** — adds `docs/superpowers/` to `.gitignore` so planning artifacts written by Claude Code's superpowers skills don't show up as untracked. Adds a \"Local-only paths\" section to `CLAUDE.md` that lists every path contributors should never stage and a one-line reminder to rebase onto `origin/main` before starting branch work so .gitignore updates land.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_container_smoke.py -q` — 78 passed (no test changes)
- [x] `ruff check src/ tests/` — clean
- [x] ConfigMap YAML still parses to a valid dict matching `DEFAULT_CONFIG`
- [x] README JSON example now matches live formatter output character-for-character

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)