### PR TITLE
chore: anonymize range_test_app.json fixture and assertions

### DIFF
--- a/tests/payloads/range_test_app.json
+++ b/tests/payloads/range_test_app.json
@@ -1,6 +1,6 @@
 {
   "channel": 0,
-  "from": 2640243444,
+  "from": 2852126730,
   "id": 1455581347,
   "payload": {
     "decoded": {
@@ -13,7 +13,7 @@
     "rx_time": 1714392055,
     "want_ack": false
   },
-  "sender": "!9d5f3af4",
+  "sender": "!cc00000a",
   "to": 4294967295,
   "type": "packet"
 }

--- a/tests/test_zerohop.py
+++ b/tests/test_zerohop.py
@@ -541,14 +541,14 @@ class TestProcessMessageUnmockedJson:
         # Gateway publishes on its own !sender topic
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
             result = process_message(
-                "msh/US/2/json/LongFast/!9d5f3af4", payload, config,
+                "msh/US/2/json/LongFast/!cc00000a", payload, config,
             )
         assert result is None
         rec = [r for r in caplog.records if getattr(r, "outcome", None) == "noop"]
         assert len(rec) == 1
         assert getattr(rec[0], "id") == 1455581347
         # `from` is sourced from JSON's `from` field (originating node), not `sender`
-        assert getattr(rec[0], "from") == "!9d5eeaf4"
+        assert getattr(rec[0], "from") == "!aa00000a"
         assert getattr(rec[0], "to") == "!ffffffff"
         assert getattr(rec[0], "hop_limit") == 0
 


### PR DESCRIPTION
## Summary

The first JSON fixture added to `tests/payloads/` was committed before the directory's anonymization scheme was in place. The other JSON fixtures (and all the protobuf binaries) use synthetic 0xAA-prefixed `from` values and 0xCC-prefixed `sender` strings; this one carried the original captured node identifiers through to merge.

This PR replaces the `from` and `sender` fields with synthetic values matching the rest of the directory (slot 0x0a — previously unused). The matching test assertions and the topic string in the test harness are updated to match the new fixture state.

## Notes

- Packet `id` is left as-is across all JSON fixtures: it is a random 32-bit per-packet value generated by the originating firmware and does not identify a node on its own. Anonymizing it would not improve PII protection and would unnecessarily diverge the fixture from real-world structure.
- The original fixture commit is reachable via git history; rewriting that history is out of scope for a regular PR. The exposed values were public broadcast IDs visible to anyone monitoring the public Meshtastic MQTT broker, but they should not have been committed to a public repo.

## Test plan

- [x] `pytest tests/test_zerohop.py::TestProcessMessageUnmockedJson::test_range_test_app_real_world_payload -v` — passes
- [x] `pytest tests/ --ignore=tests/test_container_smoke.py -q` — 122 passed
- [x] `ruff check src/ tests/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)