### PR TITLE
chore: redirect ruff and pytest caches out of the working tree

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,15 @@ where = ["src"]
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+# Keep ruff's incremental cache out of the working tree so the repo
+# stays clean. Path is per-machine; CI builds get a fresh cache anyway.
+cache-dir = "/tmp/ruff_cache_floodgate"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# Same rationale as ruff cache-dir above. /tmp survives a single
+# session but gets wiped on reboot, which is fine for dev caches.
+cache_dir = "/tmp/pytest_cache_floodgate"


### PR DESCRIPTION
## Summary

Two tiny developer-experience cleanups, no behavior changes.

### 1. Cache directories out of the repo

`pytest` and `ruff` were both dropping cache directories at the project root (`.pytest_cache/`, `.ruff_cache/`). They're gitignored so they don't pollute commits, but they pollute the working tree and obscure project structure when browsing files. The cache speedups are trivial on a project this small (full suite runs in ~1.3s, ruff lints in <100ms).

Set `cache_dir` / `cache-dir` in `pyproject.toml` to `/tmp` so caches land per-machine and never appear in the repo. CI runs always build a fresh cache anyway, so this is purely developer-tree hygiene.

### 2. Drop redundant `protobufs/.gitkeep`

The existing `protobufs/README.md` already keeps the directory tracked when its contents are gitignored, and the README explicitly documents the directory's purpose (fetched at build time by `scripts/download_protobufs.sh`). The empty `.gitkeep` adds nothing.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_container_smoke.py -q` — 122 passed
- [x] `ruff check src/ tests/` — clean
- [x] After running both, no `.pytest_cache/` or `.ruff_cache/` appears in the project tree (caches now live at `/tmp/pytest_cache_floodgate/` and `/tmp/ruff_cache_floodgate/`)
- [x] `protobufs/` still has `README.md` so the directory remains tracked

## Note on `__pycache__`

The remaining cache directories sprinkled around the tree are `__pycache__/` from Python's bytecode compiler. Disabling those is per-shell (`export PYTHONDONTWRITEBYTECODE=1`) rather than per-project, so it isn't covered here. They're already gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)