### PR TITLE
feat: portnum drop filter and zerohop config rename (#29)

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,9 @@
+# Project-level dev environment vars. Source before working in the repo:
+#   set -a; . ./.env; set +a
+# (or use direnv / your editor's .env loader)
+#
+# Don't put secrets here — this file is committed. Personal overrides go in
+# .env.local, which is gitignored.
+
+# Stop Python from writing __pycache__/ trees in the working tree.
+PYTHONDONTWRITEBYTECODE=1

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,11 @@ build/
 .venv/
 venv/
 
-# Environment files
-.env
+# Personal env overrides — the tracked .env carries shared dev-convenience
+# vars (PYTHONDONTWRITEBYTECODE etc.); .env.local is for per-developer extras
+# and stays out of git. Don't put secrets in either; floodgate has no secret
+# config.
+.env.local
 
 # Test caches and coverage artefacts
 .pytest_cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,23 +1,29 @@
 # floodgate
 
-Zero-hop MQTT anti-flood service for Meshtastic. Intercepts MQTT PUBLISH events via
-EMQX ExHook (gRPC) and sets `MeshPacket.hop_limit=0` in-flight before delivery to subscribers.
+MQTT anti-flood service for Meshtastic with two operations:
+
+- **Zerohop** — modify `MeshPacket.hop_limit` to 0 in-flight, then deliver. Default behaviour for the standard public channel presets.
+- **Drop** — deny a publish entirely so EMQX never delivers it. Off by default; intended for portnum-based spam (e.g. `RANGE_TEST_APP` on the public channels).
+
+Drop runs *before* zerohop. Both are evaluated per message via the EMQX ExHook gRPC interface.
 
 ## Architecture
 
 ```
-Gateway → EMQX → [ExHook gRPC] → floodgate → modified payload → EMQX → Subscribers
+Gateway → EMQX → [ExHook gRPC] → floodgate → drop / modify / passthru → EMQX → Subscribers
 ```
 
 | File | Role |
 |------|------|
-| `src/floodgate/exhook_server.py` | gRPC server; EMQX connects here |
-| `src/floodgate/zerohop.py` | Core logic: packet decode, zero-hop, structured logging |
-| `src/floodgate/config.py` | Config loader; channel policy evaluation |
-| `src/floodgate/log_setup.py` | Logging formatter; text and JSON (Loki) modes |
-| `src/floodgate/health.py` | HTTP health check server on `health_port` |
-| `src/floodgate/__main__.py` | CLI entry point |
-| `proto/emqx/exhook.proto` | EMQX ExHook interface definition |
+| `src/floodgate/exhook_server.py` | gRPC server; EMQX connects here. Maps process_message actions to ExHook responses. |
+| `src/floodgate/zerohop.py`       | Per-message pipeline: drop check → zerohop check → structured logging. |
+| `src/floodgate/config.py`        | Config loader, schema validation (rejects removed keys), policy helpers `should_zerohop` / `should_drop`. |
+| `src/floodgate/decrypt.py`       | AES-128-CTR decryption with the Meshtastic default key (drop's portnum lookup needs this for `/e/` packets). |
+| `src/floodgate/portnum.py`       | Portnum extraction from `/e/` (decrypt + Data parse) and `/json/` payloads. |
+| `src/floodgate/log_setup.py`     | Logging formatter; text and JSON (Loki) modes. |
+| `src/floodgate/health.py`        | HTTP health check server on `health_port`. |
+| `src/floodgate/__main__.py`      | CLI entry point. |
+| `proto/emqx/exhook.proto`        | EMQX ExHook interface definition. |
 
 ## Dev Setup
 
@@ -31,11 +37,12 @@ pytest tests/ --ignore=tests/test_container_smoke.py -q   # no Docker required
 pytest tests/ -q   # full suite including container smoke test (requires Docker)
 ```
 
-Tests mock protobuf imports for the routing-logic suite, so it runs without
-protobufs (handy for fast iteration). Tests under
-`tests/payloads/protobuf/` exercise `zerohop_protobuf` against real binary
-fixtures and require the generated stubs — they skip automatically when
-the stubs aren't present, and CI generates them before running tests.
+Routing-logic tests mock the low-level zerohop functions, so the suite runs
+without Meshtastic protobufs (handy for fast iteration). Tests that exercise
+real protobuf payloads (under `tests/payloads/protobuf/`, plus the decrypt
+and portnum tests that build synthetic envelopes) skip automatically via
+`pytest.importorskip("meshtastic")` when the generated stubs aren't present.
+CI generates the stubs before running tests, so the full suite runs there.
 
 ## Running
 
@@ -44,7 +51,7 @@ floodgate --config config.yaml
 floodgate --config config.yaml -v   # verbose DEBUG logging (decode steps, gRPC calls)
 ```
 
-Per-message outcomes (`[ZEROHOP]`, `[PASSTHRU]`, `[NOOP]`) are logged at **INFO** level. No
+Per-message outcomes (`[ZEROHOP]`, `[PASSTHRU]`, `[NOOP]`, `[DROPPED]`) are logged at **INFO** level. No
 special flag needed to see them. `-v` enables DEBUG for internal decode and gRPC detail.
 
 Or with Docker Compose (includes EMQX):
@@ -65,14 +72,20 @@ After startup, register the ExHook in EMQX (see README Deployment section for th
 
 ## Key Config Options
 
+Drop runs **before** zerohop. A packet matched by drop is denied entirely and never reaches the zerohop check.
+
 | Key | Default | Effect |
 |-----|---------|--------|
-| `channel_policy` | `blacklist` | `blacklist` (default): zero-hop only listed channels. `whitelist`: zero-hop all except listed. |
-| `channel_blacklist` | 8 standard presets | Channels to zero-hop (blacklist mode). Default = all standard Meshtastic public presets. |
-| `channel_whitelist` | `[]` | Channels exempt from zero-hop (whitelist mode). Empty = zero-hop everything. |
+| `zerohop_enabled` | `true` | Master switch for the zero-hop modifier. |
+| `zerohop_channels` | 8 standard presets | Channels whose packets get `hop_limit` zeroed. |
+| `drop_enabled` | `false` | Master switch for the drop filter. |
+| `drop_channels` | `"zerohop_channels"` | Drop scope. List of channels, the literal string `"zerohop_channels"` to inherit, or `null` for all channels. |
+| `drop_portnums` | `[]` | Meshtastic portnums (proto enum names like `RANGE_TEST_APP`) to drop. Only readable on default-key (`AQ==`) protobuf channels and on JSON channels. |
 | `log_level` | `INFO` | `INFO` logs per-message outcomes. `DEBUG` adds decode/gRPC internals. |
 | `log_format` | `text` | `text` (default) or `json` for Loki/Grafana. Override with `FLOODGATE_LOG_FORMAT` env var. |
 | `stats_log` | `true` | Log periodic stats summaries. Set `false` to disable. |
+
+The pre-rename keys `channel_policy` / `channel_blacklist` / `channel_whitelist` were removed. floodgate refuses to load a config containing any of them and prints the new equivalents.
 
 ## Documentation and Test Discipline
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,11 @@ Every PR and push to `main` runs four jobs in sequence:
 ### Running locally
 
 ```bash
+# Source the project .env once per shell to pick up dev-convenience vars
+# (currently just PYTHONDONTWRITEBYTECODE=1 to keep __pycache__ out of the
+# working tree). direnv users can skip this — direnv loads it automatically.
+set -a; . ./.env; set +a
+
 # Unit tests (fast, no Docker needed). Protobuf-dependent tests skip
 # automatically if you haven't generated stubs yet.
 pytest tests/ --ignore=tests/test_container_smoke.py -q

--- a/README.md
+++ b/README.md
@@ -29,11 +29,14 @@ Each message produces one outcome:
 
 | Outcome | Condition |
 |---------|-----------|
-| `zerohop` | Channel matched policy, `hop_limit > 0` — zeroed |
-| `noop` | Channel matched policy, already `hop_limit=0` |
-| `passthru` | Channel exempt by policy — unchanged |
-| `warn` | Payload parse failure — unchanged |
+| `dropped` | Matched the drop filter — denied entirely; EMQX never delivers it |
+| `zerohop` | Channel in `zerohop_channels`, `hop_limit > 0` — zeroed and delivered |
+| `noop` | Channel in `zerohop_channels`, already `hop_limit=0` — delivered unchanged |
+| `passthru` | Channel not in `zerohop_channels` (or zerohop disabled) — delivered unchanged |
+| `warn` | Payload parse failure — delivered unchanged |
 | `skipped` | Non-packet topic (map report, stat, etc.) — silently ignored |
+
+The drop filter runs **before** zerohop. A packet matching both is reported as `dropped`.
 
 ## Deployment
 
@@ -121,9 +124,11 @@ See [config.yaml](config.yaml) for a fully annotated example.
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `channel_policy` | `blacklist` | See policy docs below. |
-| `channel_blacklist` | 8 standard presets | Channels to zero-hop (blacklist mode). |
-| `channel_whitelist` | `[]` | Channels exempt from zero-hop (whitelist mode). |
+| `zerohop_enabled` | `true` | Master switch for the zero-hop modifier. |
+| `zerohop_channels` | 8 standard presets | Channels whose packets get `hop_limit` zeroed. |
+| `drop_enabled` | `false` | Master switch for the drop filter (deny entirely). |
+| `drop_channels` | `"zerohop_channels"` | Channels on which the drop filter runs. List of channels, the literal string `"zerohop_channels"` to inherit, or `null` for all channels. |
+| `drop_portnums` | `[]` | Meshtastic portnums (proto enum names like `RANGE_TEST_APP`) to drop. |
 | `topic_filter` | `msh/#` | MQTT topic pattern to apply. |
 | `grpc_port` | `9000` | gRPC listen port. |
 | `health_port` | `8080` | HTTP health check port. `GET /health` returns `{"status":"ok","stats":{...}}`. |
@@ -132,14 +137,14 @@ See [config.yaml](config.yaml) for a fully annotated example.
 | `log_level` | `INFO` | `INFO` shows per-message outcomes. `DEBUG` adds verbose internals. |
 | `log_format` | `text` | `text` for human-readable output, `json` for Loki/Grafana structured logging. Can also be set via `FLOODGATE_LOG_FORMAT` env var. |
 
-### Channel policy
+> **Migrating from a pre-rename config?** The keys `channel_policy`, `channel_blacklist`, and `channel_whitelist` were removed. floodgate now refuses to start if they appear in `config.yaml` and prints the new equivalents. Update your config and restart.
 
-**`blacklist` (default)** — zero-hop only the channels named in `channel_blacklist`. All other channels are forwarded unchanged. This is the right choice for most deployments: it targets the standard Meshtastic public presets that flood radio networks, while leaving private or custom channels untouched.
+### Zerohop
 
-The default `channel_blacklist` contains the eight standard Meshtastic public channel presets:
+The default zerohop list contains the eight standard Meshtastic public channel presets:
 ```yaml
-channel_policy: "blacklist"
-channel_blacklist:
+zerohop_enabled: true
+zerohop_channels:
   - "LongTurbo"
   - "LongFast"
   - "LongModerate"
@@ -150,20 +155,29 @@ channel_blacklist:
   - "ShortTurbo"
 ```
 
-**`whitelist`** — zero-hop ALL channels *except* those named in `channel_whitelist`. Use this for blanket enforcement when you want every channel zeroed with only specific exemptions.
+To zero-hop every channel a gateway forwards (maximum enforcement), pass them all in `zerohop_channels`. To leave a private channel rebroadcasting normally, omit it from the list. To turn the modifier off entirely (e.g. during a maintenance window), set `zerohop_enabled: false`.
 
-To zero-hop every packet with no exceptions — maximum enforcement — use an empty whitelist:
+### Drop
+
+The drop filter denies a publish entirely — EMQX does not deliver it to subscribers, so it doesn't appear in MQTT consumers, dashboards, or chat logs. Drop runs *before* zerohop; a dropped packet never reaches the zerohop check.
+
+The motivating use case is portnum traffic that floods the standard public channels and isn't useful in MQTT downstream — for example, `RANGE_TEST_APP`:
 ```yaml
-channel_policy: "whitelist"
-channel_whitelist: []
+drop_enabled: true
+drop_channels: "zerohop_channels"   # same scope as zerohop
+drop_portnums:
+  - "RANGE_TEST_APP"
 ```
 
-To exempt specific channels (e.g. a private channel your gateways should rebroadcast normally):
-```yaml
-channel_policy: "whitelist"
-channel_whitelist:
-  - "MyPrivateChannel"
-```
+`drop_channels` accepts:
+
+- the literal string `"zerohop_channels"` to reuse the same list as `zerohop_channels` (default — keeps drop scope aligned with zerohop scope without duplication),
+- an explicit list of channel names, e.g. `["LongFast", "MediumFast"]`,
+- `null` (or an empty list) to apply on all channels.
+
+> **Encryption constraint.** `drop_portnums` only acts on packets whose portnum floodgate can read. For protobuf (`/e/`) topics that means channels using the default Meshtastic encryption key (`AQ==`); custom-keyed channels are unreadable and therefore always delivered. JSON (`/json/`) topics expose the portnum directly and have no such limitation.
+
+> **Publisher behavior.** When floodgate denies a publish, EMQX still sends a normal PUBACK to the publisher — there's no protocol-level signal back to the gateway that its message was filtered. This is a property of the EMQX ExHook deny mechanism, not floodgate. Operators monitoring publisher-side success counters won't see drops; the floodgate `dropped` counter and per-message log lines are the source of truth.
 
 ### ExHook failure policy
 
@@ -214,9 +228,10 @@ curl -s http://localhost:8080/health | jq .
     "zerohop": 142,
     "passthru": 3,
     "noop": 0,
+    "dropped": 4,
     "skipped": 1050,
     "errors": 0,
-    "total": 1195
+    "total": 1199
   }
 }
 ```
@@ -229,8 +244,9 @@ Per-message outcomes are logged at **INFO** — no special flags required. Field
 ```
 2026-04-01 12:00:01 INFO     [floodgate.zerohop] [ZEROHOP] topic=msh/US/2/e/LongFast/!a2e1a8c4 channel=LongFast encoding=e id=3827461829 from=!a2e1a8c4 to=!ffffffff hop_limit=3 hop_start=3
 2026-04-01 12:00:02 INFO     [floodgate.zerohop] [NOOP] topic=msh/US/2/e/LongFast/!b3c4d5e6 channel=LongFast encoding=e id=2019283746 from=!b3c4d5e6 to=!ffffffff hop_limit=0 hop_start=3
+2026-04-01 12:00:08 INFO     [floodgate.zerohop] [DROPPED] topic=msh/US/2/e/LongFast/!c1c2c3c4 channel=LongFast encoding=e portnum=RANGE_TEST_APP id=694258842 from=!c1c2c3c4 to=!ffffffff
 2026-04-01 12:00:15 INFO     [floodgate.zerohop] [PASSTHRU] topic=msh/US/2/e/MyPrivate/!a2e1a8c4 channel=MyPrivate encoding=e id=1234567890 from=!a2e1a8c4 to=!ffffffff
-2026-04-01 12:01:01 INFO     [floodgate.exhook_server] [STATS] interval_s=60 zerohop=142 passthru=1 noop=0 skipped=1050 errors=0 total=1193
+2026-04-01 12:01:01 INFO     [floodgate.exhook_server] [STATS] interval_s=60 zerohop=142 passthru=1 noop=0 dropped=4 skipped=1050 errors=0 total=1197
 ```
 
 **JSON mode** (`log_format: json` or `FLOODGATE_LOG_FORMAT=json`):
@@ -298,7 +314,7 @@ pytest tests/ -q   # full suite including container smoke test (requires Docker)
 ```
 2026-04-01 14:23:47 INFO     [floodgate.zerohop] [ZEROHOP] topic=msh/US/2/e/LongFast/!a2e1a8c4 channel=LongFast encoding=e id=3827461829 from=!a2e1a8c4 to=!ffffffff hop_limit=3 hop_start=3
 2026-04-01 14:23:48 INFO     [floodgate.zerohop] [PASSTHRU] topic=msh/US/2/e/MyPrivate/!a2e1a8c4 channel=MyPrivate encoding=e id=1234567890 from=!a2e1a8c4 to=!ffffffff
-2026-04-01 14:24:47 INFO     [floodgate.exhook_server] [STATS] interval_s=60 zerohop=142 passthru=3 noop=0 skipped=1050 errors=0 total=1195
+2026-04-01 14:24:47 INFO     [floodgate.exhook_server] [STATS] interval_s=60 zerohop=142 passthru=3 noop=0 dropped=2 skipped=1050 errors=0 total=1197
 ```
 
 ## Legal

--- a/config.yaml
+++ b/config.yaml
@@ -1,11 +1,11 @@
 # floodgate configuration
 
-# Channel policy: "blacklist" (zero-hop only listed channels) or
-#                 "whitelist" (zero-hop all except listed channels)
-channel_policy: "blacklist"
+# Zerohop: modify hop_limit to 0 and let EMQX deliver the modified packet.
+# This is the core anti-flood behavior — without it floodgate is a no-op.
+zerohop_enabled: true
 
-# Channels to zero-hop (blacklist mode). Standard Meshtastic public presets.
-channel_blacklist:
+# Channels to zero-hop. Standard Meshtastic public presets.
+zerohop_channels:
   - "LongTurbo"
   - "LongFast"
   - "LongModerate"
@@ -15,8 +15,23 @@ channel_blacklist:
   - "ShortSlow"
   - "ShortTurbo"
 
-# Channels exempt from zero-hop (whitelist mode only).
-channel_whitelist: []
+# Drop: deny the publish entirely so EMQX never delivers it to subscribers.
+# Disabled by default. Drop is checked BEFORE zerohop — a dropped packet
+# never reaches the zerohop logic.
+drop_enabled: false
+
+# Channels on which the drop filter is active. Three forms accepted:
+#   "zerohop_channels" — reuse the same list as zerohop_channels (default)
+#   ["LongFast", ...]  — explicit list of channel names
+#   null               — apply to ALL channels (no scoping)
+drop_channels: "zerohop_channels"
+
+# Portnums to drop, by Meshtastic proto enum name. See:
+# https://buf.build/meshtastic/protobufs/docs/main:meshtastic#meshtastic.PortNum
+# Note: drop only acts on packets whose portnum floodgate can read. For
+# protobuf (/e/) topics that means channels using the default encryption key
+# (AQ==); custom-keyed channels are always delivered.
+drop_portnums: []
 
 grpc_port: 9000
 health_port: 8080
@@ -30,6 +45,6 @@ log_level: "INFO"
 # Override with FLOODGATE_LOG_FORMAT env var.
 log_format: "text"
 
-# Log periodic stats summary (zerohop/passthru/noop counts).
+# Log periodic stats summary (zerohop/passthru/noop/dropped counts).
 # Set false to disable stats log lines.
 stats_log: true

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -4,9 +4,8 @@ metadata:
   name: floodgate-config
 data:
   config.yaml: |
-    channel_policy: "blacklist"
-    channel_whitelist: []
-    channel_blacklist:
+    zerohop_enabled: true
+    zerohop_channels:
       - "LongTurbo"
       - "LongFast"
       - "LongModerate"
@@ -15,6 +14,9 @@ data:
       - "ShortFast"
       - "ShortSlow"
       - "ShortTurbo"
+    drop_enabled: false
+    drop_channels: "zerohop_channels"
+    drop_portnums: []
     grpc_port: 9000
     health_port: 8080
     topic_filter: "msh/#"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "paho-mqtt>=2.0.0",
     "pyyaml>=6.0",
     "python-json-logger>=2.0",
+    "cryptography>=42",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ protobuf>=4.25.0
 paho-mqtt>=2.0.0
 pyyaml>=6.0
 python-json-logger>=2.0
+cryptography>=42

--- a/src/floodgate/__main__.py
+++ b/src/floodgate/__main__.py
@@ -28,7 +28,8 @@ def main():
         action="store_true",
         help=(
             "Enable DEBUG logging — very verbose (decode steps, byte counts, gRPC calls). "
-            "INFO already shows per-message outcomes ([ZEROHOP]/[PASSTHRU]/[NOOP]). "
+            "INFO already shows per-message outcomes "
+            "([ZEROHOP]/[PASSTHRU]/[NOOP]/[DROPPED]). "
             "Equivalent to log_level: DEBUG in config.yaml."
         ),
     )

--- a/src/floodgate/config.py
+++ b/src/floodgate/config.py
@@ -1,4 +1,4 @@
-"""Configuration loader."""
+"""Configuration loader, schema validation, and policy evaluation."""
 
 import logging
 import os
@@ -9,10 +9,23 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_CONFIG = {
-    "channel_policy": "blacklist",
-    "channel_whitelist": [],
-    "channel_blacklist": [
+# Sentinel string accepted in YAML for `drop_channels` to mean "use the same
+# channel list as `zerohop_channels`". Avoids forcing users to maintain two
+# identical lists when they want both filters scoped the same way.
+INHERIT_ZEROHOP_CHANNELS = "zerohop_channels"
+
+# Removed in this release; keys present in user YAML trigger ConfigError.
+_REMOVED_KEYS = {
+    "channel_policy":    "Replaced by `zerohop_enabled` (bool) and `zerohop_channels` (list).",
+    "channel_blacklist": "Renamed to `zerohop_channels`.",
+    "channel_whitelist": "Removed (whitelist mode is gone — use `zerohop_enabled: false` "
+                         "or an empty `zerohop_channels` list).",
+}
+
+DEFAULT_CONFIG: dict[str, Any] = {
+    # Zerohop: modify hop_limit to 0 and deliver. Existing behavior, new names.
+    "zerohop_enabled": True,
+    "zerohop_channels": [
         "LongTurbo",
         "LongFast",
         "LongModerate",
@@ -22,48 +35,67 @@ DEFAULT_CONFIG = {
         "ShortSlow",
         "ShortTurbo",
     ],
-    "grpc_port": 9000,
-    "health_port": 8080,
-    # MQTT topic filter passed to EMQX ExHook — controls which topics EMQX
-    # sends to this service. Use '#' suffix for wildcard subtopics.
-    # Default covers all Meshtastic traffic regardless of region depth.
-    "topic_filter": "msh/#",
-    # How often (seconds) to emit a rolling stats summary at INFO level
+
+    # Drop: deny entirely (EMQX does not deliver). Disabled by default.
+    "drop_enabled":  False,
+    "drop_channels": INHERIT_ZEROHOP_CHANNELS,
+    "drop_portnums": [],
+
+    # Transport / runtime
+    "grpc_port":        9000,
+    "health_port":      8080,
+    "topic_filter":     "msh/#",
     "stats_interval_s": 60,
-    "log_level": "INFO",
-    "log_format": "text",   # "text" | "json"
-    "stats_log": True,
+    "log_level":        "INFO",
+    "log_format":       "text",   # "text" | "json"
+    "stats_log":        True,
 }
 
 
+class ConfigError(ValueError):
+    """Raised at config-load time for unrecoverable schema problems."""
+
+
 def load_config(config_path: str | None = None) -> dict[str, Any]:
-    """Load configuration from YAML file, with defaults."""
+    """Load configuration from YAML, merge over defaults, and pre-compute lookup sets.
+
+    Raises ConfigError if the YAML file uses keys removed in this release.
+    """
     config = _deep_copy_dict(DEFAULT_CONFIG)
 
     if config_path is None:
         config_path = os.environ.get("FLOODGATE_CONFIG")
 
+    user_keys: set[str] = set()
     if config_path:
         path = Path(config_path)
         if path.exists():
             logger.info("Loading config from %s", path)
             with open(path) as f:
                 user_config = yaml.safe_load(f) or {}
+            user_keys = set(user_config.keys())
+            _reject_removed_keys(user_keys, source=str(path))
             _deep_merge(config, user_config)
         else:
             logger.warning("Config file %s not found, using defaults", path)
 
-    # ENV var override for log_format — convenient for Docker/k8s without touching config files
+    # FLOODGATE_LOG_FORMAT is convenient in container/k8s environments where
+    # editing the mounted config.yaml is awkward.
     env_fmt = os.environ.get("FLOODGATE_LOG_FORMAT")
     if env_fmt is not None:
         config["log_format"] = env_fmt.lower()
 
-    # Pre-compute sets for fast lookup
-    # Use 'or []' to guard against YAML null (channel_whitelist: with no entries)
-    config["_whitelist_set"] = set(config.get("channel_whitelist") or [])
-    config["_blacklist_set"] = set(config.get("channel_blacklist") or [])
+    config["_zerohop_channels_set"] = _validate_string_list(
+        config.get("zerohop_channels"), key="zerohop_channels",
+    )
+    config["_drop_channels_set"]    = _resolve_drop_channels(
+        config.get("drop_channels"),
+        config["_zerohop_channels_set"],
+    )
+    config["_drop_portnums_set"]    = _validate_string_list(
+        config.get("drop_portnums"), key="drop_portnums",
+    )
 
-    # Apply log level
     log_level = config.get("log_level", "INFO").upper()
     logging.getLogger("floodgate").setLevel(getattr(logging, log_level, logging.INFO))
 
@@ -71,24 +103,92 @@ def load_config(config_path: str | None = None) -> dict[str, Any]:
 
 
 def should_zerohop(config: dict, channel_name: str) -> bool:
-    """Determine whether a channel's packets should be zero-hopped.
+    """True if a packet on `channel_name` should have hop_limit zeroed."""
+    if not config.get("zerohop_enabled", True):
+        return False
+    return channel_name in config["_zerohop_channels_set"]
 
-    - whitelist policy: zero-hop everything EXCEPT channels in whitelist
-    - blacklist policy: zero-hop ONLY channels in blacklist
+
+def should_drop(config: dict, channel_name: str, portnum: str | None) -> bool:
+    """True if a packet should be denied (EMQX will not deliver it).
+
+    `portnum` may be None when floodgate cannot read it (custom-keyed
+    encrypted packet, JSON without recognizable type, etc.) — in that
+    case we always deliver, since drop is destructive.
     """
-    policy = config.get("channel_policy", "whitelist")
-
-    if policy == "whitelist":
-        return channel_name not in config["_whitelist_set"]
-    elif policy == "blacklist":
-        return channel_name in config["_blacklist_set"]
-    else:
-        logger.warning("Unknown channel_policy '%s', defaulting to zero-hop", policy)
+    if not config.get("drop_enabled", False):
+        return False
+    if portnum is None:
+        return False
+    if portnum not in config["_drop_portnums_set"]:
+        return False
+    drop_channels = config["_drop_channels_set"]
+    # None ⇒ "all channels" (no scoping)
+    if drop_channels is None:
         return True
+    return channel_name in drop_channels
+
+
+def _resolve_drop_channels(value, zerohop_set: set[str]) -> set[str] | None:
+    """Translate the raw `drop_channels` config value into a lookup set or None.
+
+    None / [] / missing  → None  (means "all channels")
+    "zerohop_channels"   → a copy of the zerohop set
+    list of strings      → set(value)
+    anything else        → ConfigError
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        if value == INHERIT_ZEROHOP_CHANNELS:
+            return set(zerohop_set)
+        raise ConfigError(
+            f"`drop_channels` must be a list, null, or the literal string "
+            f"{INHERIT_ZEROHOP_CHANNELS!r}; got {value!r}"
+        )
+    if isinstance(value, list):
+        if not value:
+            return None
+        return _validate_string_list(value, key="drop_channels")
+    raise ConfigError(
+        f"`drop_channels` must be a list, null, or the literal string "
+        f"{INHERIT_ZEROHOP_CHANNELS!r}; got {type(value).__name__}"
+    )
+
+
+def _validate_string_list(value, key: str) -> set[str]:
+    """Coerce a YAML list into a set of strings; reject non-string entries.
+
+    Without this check, e.g. a portnum given as `66` (the int) instead of
+    `"RANGE_TEST_APP"` would silently never match anything at runtime.
+    """
+    if value is None:
+        return set()
+    if not isinstance(value, list):
+        raise ConfigError(f"`{key}` must be a list of strings; got {type(value).__name__}")
+    bad = [v for v in value if not isinstance(v, str)]
+    if bad:
+        raise ConfigError(
+            f"`{key}` entries must be strings; got non-string entries: {bad!r}"
+        )
+    return set(value)
+
+
+def _reject_removed_keys(user_keys: set[str], source: str) -> None:
+    found = sorted(user_keys & _REMOVED_KEYS.keys())
+    if not found:
+        return
+    lines = [f"  - {k}: {_REMOVED_KEYS[k]}" for k in found]
+    raise ConfigError(
+        f"Removed config key(s) found in {source}:\n"
+        + "\n".join(lines)
+        + "\nUpdate your config — see README.md `Configuration` for the new schema."
+    )
 
 
 def _deep_copy_dict(d: dict) -> dict:
-    """Simple deep copy for nested dicts/lists."""
+    """Shallow-recursive copy of nested dicts and lists. Sufficient for our
+    config shape — no nested dicts of dicts deeper than two levels."""
     result = {}
     for k, v in d.items():
         if isinstance(v, dict):
@@ -101,7 +201,7 @@ def _deep_copy_dict(d: dict) -> dict:
 
 
 def _deep_merge(base: dict, override: dict) -> None:
-    """Merge override into base, modifying base in place."""
+    """Merge override into base in place. Lists and scalars are replaced wholesale."""
     for k, v in override.items():
         if k in base and isinstance(base[k], dict) and isinstance(v, dict):
             _deep_merge(base[k], v)

--- a/src/floodgate/decrypt.py
+++ b/src/floodgate/decrypt.py
@@ -1,0 +1,41 @@
+"""AES-128-CTR decryption for Meshtastic default-key channels.
+
+Mirrors the Meshtastic firmware reference implementation
+(meshtastic/firmware  src/mesh/CryptoEngine.cpp). Custom per-channel keys are
+intentionally out of scope — only the default PSK (`AQ==`) is supported.
+"""
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+# 16-byte AES-128 key derived from the default Meshtastic PSK (single-byte 0x01).
+# Source: meshtastic/python  meshtastic/util.py  DEFAULT_KEY constant.
+DEFAULT_KEY = bytes.fromhex("d4f1bb3a20290759f0bcffabcf4e6901")
+
+_NONCE_LEN = 16
+
+
+def build_nonce(packet_id: int, from_node: int) -> bytes:
+    """Construct the 16-byte AES-CTR nonce per Meshtastic's documented layout.
+
+    Bytes 0-7  : packet_id   (uint64 little-endian)
+    Bytes 8-11 : from_node   (uint32 little-endian)
+    Bytes 12-15: extra_nonce (uint32 little-endian, always 0 — unused by floodgate)
+    """
+    return (
+        (packet_id & 0xFFFFFFFFFFFFFFFF).to_bytes(8, "little")
+        + (from_node & 0xFFFFFFFF).to_bytes(4, "little")
+        + b"\x00\x00\x00\x00"
+    )
+
+
+def decrypt(ciphertext: bytes, packet_id: int, from_node: int,
+            key: bytes = DEFAULT_KEY) -> bytes:
+    """AES-128-CTR decrypt a Meshtastic encrypted payload.
+
+    AES-CTR is symmetric: this same call also encrypts. With a wrong key
+    the result is plausible-looking garbage — no exception is raised and
+    the caller must validate (e.g. by parsing as a Data protobuf).
+    """
+    nonce = build_nonce(packet_id, from_node)
+    cipher = Cipher(algorithms.AES(key), modes.CTR(nonce))
+    return cipher.decryptor().update(ciphertext)

--- a/src/floodgate/exhook_server.py
+++ b/src/floodgate/exhook_server.py
@@ -1,4 +1,4 @@
-"""EMQX ExHook gRPC server — intercepts PUBLISH events to modify payloads in-flight."""
+"""EMQX ExHook gRPC server — intercepts PUBLISH events to drop or modify in-flight."""
 
 import logging
 import threading
@@ -6,7 +6,7 @@ from concurrent import futures
 
 import grpc
 
-from .zerohop import process_message
+from .zerohop import ACTION_DROP, ACTION_MODIFY, process_message
 from .zerohop import stats as packet_stats
 
 logger = logging.getLogger(__name__)
@@ -54,15 +54,21 @@ class HookProviderServicer:
     def OnMessagePublish(self, request, context):
         msg = request.message
         logger.debug("OnMessagePublish: topic=%s bytes=%d", msg.topic, len(msg.payload))
-        modified_payload = process_message(msg.topic, msg.payload, self.config)
-        result = "modified" if modified_payload is not None else "pass"
-        logger.debug("OnMessagePublish: result=%s", result)
+        result = process_message(msg.topic, msg.payload, self.config)
+        logger.debug("OnMessagePublish: action=%s", result.action)
 
         resp = _exhook_pb2.ValuedResponse()
-        if modified_payload is not None:
+        if result.action == ACTION_MODIFY:
             resp.type = _exhook_pb2.ValuedResponse.STOP_AND_RETURN
             resp.message.CopyFrom(msg)
-            resp.message.payload = modified_payload
+            resp.message.payload = result.payload
+        elif result.action == ACTION_DROP:
+            # EMQX honors `allow_publish: false` in message headers to deny
+            # the publish. STOP_AND_RETURN ends the hook chain so EMQX uses
+            # this response directly.
+            resp.type = _exhook_pb2.ValuedResponse.STOP_AND_RETURN
+            resp.message.CopyFrom(msg)
+            resp.message.headers["allow_publish"] = "false"
         else:
             resp.type = _exhook_pb2.ValuedResponse.IGNORE
         return resp
@@ -148,6 +154,7 @@ def _stats_reporter(interval_s: int, stop_event: threading.Event,
                     "zerohop":    snap["zerohop"],
                     "passthru":   snap["passthru"],
                     "noop":       snap["noop"],
+                    "dropped":    snap["dropped"],
                     "skipped":    snap["skipped"],
                     "errors":     snap["errors"],
                     "total":      snap["total"],
@@ -162,34 +169,51 @@ def _stats_reporter(interval_s: int, stop_event: threading.Event,
 # ---------------------------------------------------------------------------
 
 def _log_startup_policy(config: dict):
-    policy        = config.get("channel_policy", "whitelist")
-    interval      = config.get("stats_interval_s", 60)
-    topic_filter  = config.get("topic_filter", "msh/#")
+    interval     = config.get("stats_interval_s", 60)
+    topic_filter = config.get("topic_filter", "msh/#")
     logger.info("Topic filter: %s", topic_filter)
 
-    if policy == "whitelist":
-        channels = config.get("channel_whitelist", [])
+    if config.get("zerohop_enabled", True):
+        channels = config.get("zerohop_channels", []) or []
         if channels:
             logger.info(
-                "Channel policy: WHITELIST — zero-hopping all channels EXCEPT: %s",
+                "Zerohop ENABLED — zero-hopping packets on: %s",
                 ", ".join(channels),
             )
         else:
             logger.info(
-                "Channel policy: WHITELIST — whitelist is empty, zero-hopping ALL channels"
+                "Zerohop ENABLED — `zerohop_channels` is empty, no channels will be zero-hopped"
             )
     else:
-        channels = config.get("channel_blacklist", [])
-        logger.info(
-            "Channel policy: BLACKLIST — zero-hopping only: %s",
-            ", ".join(channels) if channels else "(none configured)",
-        )
+        logger.info("Zerohop DISABLED — packets will not be zero-hopped")
+
+    if config.get("drop_enabled", False):
+        portnums = config.get("drop_portnums", []) or []
+        if not portnums:
+            logger.warning(
+                "Drop ENABLED but `drop_portnums` is empty — drop is a no-op"
+            )
+        else:
+            scope = _format_drop_channel_scope(config)
+            logger.info(
+                "Drop ENABLED — dropping portnums [%s] on %s",
+                ", ".join(portnums), scope,
+            )
+    else:
+        logger.info("Drop DISABLED")
 
     logger.info("Stats will be logged every %d seconds", interval)
     logger.info(
-        "Per-message outcomes ([ZEROHOP]/[PASSTHRU]/[NOOP]) logged at INFO.  "
+        "Per-message outcomes ([ZEROHOP]/[PASSTHRU]/[NOOP]/[DROPPED]) logged at INFO. "
         "Run with -v for verbose DEBUG."
     )
+
+
+def _format_drop_channel_scope(config: dict) -> str:
+    drop_set = config.get("_drop_channels_set")
+    if drop_set is None:
+        return "all channels"
+    return f"channels [{', '.join(sorted(drop_set))}]"
 
 
 def serve(config: dict):

--- a/src/floodgate/log_setup.py
+++ b/src/floodgate/log_setup.py
@@ -3,20 +3,23 @@
 import logging
 
 # Fields rendered by StructuredTextFormatter, in display order.
+# `portnum` appears on dropped events (and is harmless when absent on others).
 _MESSAGE_FIELDS = (
-    "topic", "channel", "encoding", "id", "from", "to",
+    "topic", "channel", "encoding", "portnum", "id", "from", "to",
     "hop_limit", "hop_start", "relay", "via_mqtt",
 )
 _STATS_FIELDS = (
-    "interval_s", "zerohop", "passthru", "noop", "skipped", "errors", "total",
+    "interval_s", "zerohop", "passthru", "noop", "dropped",
+    "skipped", "errors", "total",
 )
 
 # Outcome tags → display labels for text mode
 _OUTCOME_TAGS = {
-    "zerohop": "[ZEROHOP]",
+    "zerohop":  "[ZEROHOP]",
     "passthru": "[PASSTHRU]",
-    "noop": "[NOOP]",
-    "warn": "[WARN]",
+    "noop":     "[NOOP]",
+    "dropped":  "[DROPPED]",
+    "warn":     "[WARN]",
 }
 
 

--- a/src/floodgate/portnum.py
+++ b/src/floodgate/portnum.py
@@ -1,0 +1,117 @@
+"""Extract Meshtastic portnum names from `/e/` and `/json/` MQTT payloads.
+
+Used by the drop filter to decide whether a packet should be denied.
+For `/e/` packets, decryption with the default Meshtastic key is required
+(see `decrypt.py`); custom-keyed channels return None and are delivered.
+"""
+
+import json as _json
+import logging
+
+from .decrypt import decrypt
+
+logger = logging.getLogger(__name__)
+
+# Gateway-published JSON `type` field → proto enum name.
+# Add entries as new portnums appear in the wild. Unknown types fall through
+# to None and the packet is delivered (drop only acts on identified portnums).
+_JSON_TYPE_TO_PORTNUM = {
+    "text":           "TEXT_MESSAGE_APP",
+    "position":       "POSITION_APP",
+    "nodeinfo":       "NODEINFO_APP",
+    "telemetry":      "TELEMETRY_APP",
+    "traceroute":     "TRACEROUTE_APP",
+    "neighborinfo":   "NEIGHBORINFO_APP",
+    "rangetest":      "RANGE_TEST_APP",
+    "remotehardware": "REMOTE_HARDWARE_APP",
+    "routing":        "ROUTING_APP",
+    "admin":          "ADMIN_APP",
+    "waypoint":       "WAYPOINT_APP",
+    "detection":      "DETECTION_SENSOR_APP",
+    "paxcounter":     "PAXCOUNTER_APP",
+}
+
+_mqtt_pb2     = None
+_mesh_pb2     = None
+_portnums_pb2 = None
+
+
+def _load_protos():
+    global _mqtt_pb2, _mesh_pb2, _portnums_pb2
+    if _mqtt_pb2 is None:
+        from meshtastic import mesh_pb2, mqtt_pb2, portnums_pb2
+        _mqtt_pb2     = mqtt_pb2
+        _mesh_pb2     = mesh_pb2
+        _portnums_pb2 = portnums_pb2
+
+
+def extract_portnum_protobuf(payload: bytes) -> str | None:
+    """Return the portnum proto enum name (e.g. "RANGE_TEST_APP") for an
+    encrypted ServiceEnvelope payload, or None when it can't be determined.
+
+    Returns None when the envelope is unparseable, the inner packet has no
+    encrypted variant, or decryption produces bytes that are not a valid
+    Data protobuf — the latter typically means the channel uses a custom
+    encryption key that floodgate doesn't have.
+    """
+    try:
+        _load_protos()
+        env = _mqtt_pb2.ServiceEnvelope()
+        env.ParseFromString(payload)
+        if not env.HasField("packet"):
+            return None
+        pkt = env.packet
+        if pkt.WhichOneof("payload_variant") != "encrypted":
+            return None
+        from_node = _read_from_field(pkt)
+        plaintext = decrypt(pkt.encrypted, packet_id=pkt.id, from_node=from_node)
+        data = _mesh_pb2.Data()
+        data.ParseFromString(plaintext)
+        return _portnums_pb2.PortNum.Name(data.portnum)
+    except Exception as exc:
+        logger.debug("portnum extract (proto) failed: %s(%s)",
+                     type(exc).__name__, exc)
+        return None
+
+
+def extract_portnum_json(payload: bytes) -> str | None:
+    """Return the portnum proto enum name for a Meshtastic JSON payload, or None.
+
+    Probed in order:
+      1. `payload.decoded.portnum`  (gateway packet-wrapper, already an enum name)
+      2. top-level `portnum`         (rare: explicit field with the enum name)
+      3. `_JSON_TYPE_TO_PORTNUM[type]` (common: short-name → enum-name table)
+    """
+    try:
+        data = _json.loads(payload)
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    nested = data.get("payload")
+    if isinstance(nested, dict):
+        decoded = nested.get("decoded")
+        if isinstance(decoded, dict):
+            pn = decoded.get("portnum")
+            if isinstance(pn, str):
+                return pn
+
+    pn = data.get("portnum")
+    if isinstance(pn, str):
+        return pn
+
+    type_str = data.get("type")
+    if isinstance(type_str, str):
+        return _JSON_TYPE_TO_PORTNUM.get(type_str.lower())
+
+    return None
+
+
+def _read_from_field(pkt) -> int:
+    """Read MeshPacket.from (Python keyword — name varies by protobuf version)."""
+    fields = pkt.DESCRIPTOR.fields_by_name
+    field = fields.get("from") or fields.get("from_")
+    if field is None:
+        return 0
+    return getattr(pkt, field.name, 0) or 0

--- a/src/floodgate/zerohop.py
+++ b/src/floodgate/zerohop.py
@@ -1,4 +1,4 @@
-"""Core zero-hop logic — processes protobuf (/e/) and JSON (/json/) Meshtastic packets."""
+"""Per-message processing: drop filter, zero-hop logic, structured logging."""
 
 import json as _json
 import logging
@@ -27,27 +27,60 @@ def _load_protos():
 
 
 # ---------------------------------------------------------------------------
+# ExHook actions
+# ---------------------------------------------------------------------------
+
+# `process_message` returns one of these so the gRPC layer can translate
+# directly into an EMQX response without re-deriving intent. Strings (not
+# enums) keep log records and tests legible.
+ACTION_PASSTHRU = "passthru"   # deliver the original message unchanged
+ACTION_MODIFY   = "modify"     # deliver the modified payload (zerohop)
+ACTION_DROP     = "drop"       # deny the publish entirely
+
+
+@dataclass
+class ProcessResult:
+    """Outcome of processing one MQTT message.
+
+    `payload` is only meaningful when `action == ACTION_MODIFY`.
+    """
+    action:  str
+    payload: bytes | None = None
+
+    @classmethod
+    def passthru(cls):
+        return cls(ACTION_PASSTHRU)
+
+    @classmethod
+    def modify(cls, payload: bytes):
+        return cls(ACTION_MODIFY, payload)
+
+    @classmethod
+    def drop(cls):
+        return cls(ACTION_DROP)
+
+
+# ---------------------------------------------------------------------------
 # Statistics
 # ---------------------------------------------------------------------------
 
-_COUNTER_NAMES = ("zerohop", "passthru", "noop", "skipped", "errors")
+_COUNTER_NAMES = ("zerohop", "passthru", "noop", "dropped", "skipped", "errors")
 
 
 @dataclass
 class AntifloodStats:
     """Thread-safe packet counters.
 
-    Two sets: rolling window (reset each stats interval) and lifetime
-    (cumulative, never reset). The stats reporter reads rolling via reset();
-    the health endpoint reads lifetime via snapshot().
+    Two views: rolling (reset every stats interval, surfaced in periodic
+    logs) and lifetime (cumulative, surfaced via /health).
     """
-    # Rolling window — reset by stats reporter each interval
     zerohop:  int = 0
     passthru: int = 0
     noop:     int = 0
+    dropped:  int = 0
     skipped:  int = 0
     errors:   int = 0
-    # Lifetime — never reset
+
     _lifetime: dict = field(default_factory=lambda: {k: 0 for k in _COUNTER_NAMES})
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
 
@@ -58,21 +91,22 @@ class AntifloodStats:
 
     @property
     def total(self) -> int:
-        return self.zerohop + self.passthru + self.noop + self.skipped + self.errors
+        return sum(getattr(self, k) for k in _COUNTER_NAMES)
 
     def snapshot(self) -> dict:
-        """Return lifetime cumulative counters (for health endpoint)."""
+        """Lifetime cumulative counters (for /health)."""
         with self._lock:
             snap = dict(self._lifetime)
             snap["total"] = sum(self._lifetime.values())
             return snap
 
     def reset(self) -> dict:
-        """Return rolling window snapshot then reset rolling counters to zero."""
+        """Rolling-window snapshot, then zero the rolling counters."""
         with self._lock:
             snap = {k: getattr(self, k) for k in _COUNTER_NAMES}
-            snap["total"] = self.total
-            self.zerohop = self.passthru = self.noop = self.skipped = self.errors = 0
+            snap["total"] = sum(snap.values())
+            for k in _COUNTER_NAMES:
+                setattr(self, k, 0)
             return snap
 
 
@@ -283,11 +317,11 @@ def zerohop_json(payload: bytes) -> tuple[bytes | None, int | None, dict]:
 # Main entry point
 # ---------------------------------------------------------------------------
 
-def process_message(topic: str, payload: bytes, config: dict) -> bytes | None:
-    """Process one MQTT message; return modified payload or None (pass-through).
+def process_message(topic: str, payload: bytes, config: dict) -> ProcessResult:
+    """Process one MQTT message; return a ProcessResult describing the action.
 
-    Outcomes logged at INFO: zerohop, passthru, noop, warn.
-    Non-packet topics silently skipped (counted in stats).
+    Outcomes logged at INFO: zerohop, passthru, noop, dropped, warn.
+    Non-packet topics are silently skipped (counted in stats only).
     """
     try:
         return _process_message_inner(topic, payload, config)
@@ -298,21 +332,46 @@ def process_message(topic: str, payload: bytes, config: dict) -> bytes | None:
             topic, type(exc).__name__, exc,
             exc_info=True,
         )
-        return None
+        return ProcessResult.passthru()
 
 
-def _process_message_inner(topic: str, payload: bytes, config: dict) -> bytes | None:
-    from .config import should_zerohop
+def _process_message_inner(topic: str, payload: bytes, config: dict) -> ProcessResult:
+    from .config import should_drop, should_zerohop
+    from .portnum import extract_portnum_json, extract_portnum_protobuf
 
     parsed = parse_meshtastic_topic(topic)
     if parsed is None:
         # Map reports, stat topics, non-msh — silently ignore.
         # Counted in 'skipped' for stats but no per-message log line.
         stats.inc("skipped")
-        return None
+        return ProcessResult.passthru()
 
     channel, encoding = parsed
 
+    # ---- Drop check (runs before zerohop) ----
+    if config.get("drop_enabled"):
+        portnum = (extract_portnum_json(payload) if encoding == "json"
+                   else extract_portnum_protobuf(payload))
+        if should_drop(config, channel, portnum):
+            stats.inc("dropped")
+            meta = _peek_meta(encoding, payload)
+            logger.info(
+                "dropped",
+                extra={
+                    "event":    "message",
+                    "outcome":  "dropped",
+                    "topic":    topic,
+                    "channel":  channel,
+                    "encoding": encoding,
+                    "portnum":  portnum,
+                    "id":       meta.get("packet_id"),
+                    "from":     _fmt_node(meta.get("sender")),
+                    "to":       _fmt_node(meta.get("destination")),
+                },
+            )
+            return ProcessResult.drop()
+
+    # ---- Zerohop check ----
     if not should_zerohop(config, channel):
         stats.inc("passthru")
         meta = _peek_meta(encoding, payload)
@@ -333,7 +392,7 @@ def _process_message_inner(topic: str, payload: bytes, config: dict) -> bytes | 
                 "via_mqtt":  meta.get("via_mqtt"),
             },
         )
-        return None
+        return ProcessResult.passthru()
 
     if encoding == "json":
         modified, old_hop, meta = zerohop_json(payload)
@@ -353,7 +412,7 @@ def _process_message_inner(topic: str, payload: bytes, config: dict) -> bytes | 
                 "bytes":    len(payload),
             },
         )
-        return None
+        return ProcessResult.passthru()
 
     if old_hop == 0:
         stats.inc("noop")
@@ -375,7 +434,7 @@ def _process_message_inner(topic: str, payload: bytes, config: dict) -> bytes | 
                 "via_mqtt":  meta.get("via_mqtt"),
             },
         )
-        return None
+        return ProcessResult.passthru()
 
     stats.inc("zerohop")
     relay = meta.get("relay_node")
@@ -396,4 +455,4 @@ def _process_message_inner(topic: str, payload: bytes, config: dict) -> bytes | 
             "via_mqtt":  meta.get("via_mqtt"),
         },
     )
-    return modified
+    return ProcessResult.modify(modified)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,99 +1,320 @@
-"""Tests for configuration loading and channel policy logic."""
+"""Tests for configuration loading, schema validation, and policy evaluation."""
 
+import pytest
 import yaml
 
-from floodgate.config import load_config, should_zerohop
+from floodgate.config import (
+    INHERIT_ZEROHOP_CHANNELS,
+    ConfigError,
+    load_config,
+    should_drop,
+    should_zerohop,
+)
 
+# ---------------------------------------------------------------------------
+# should_zerohop
+# ---------------------------------------------------------------------------
 
 class TestShouldZerohop:
 
-    def test_whitelist_empty_zerohops_all(self):
-        config = {"channel_policy": "whitelist", "_whitelist_set": set(), "_blacklist_set": set()}
-        assert should_zerohop(config, "LongFast") is True
-        assert should_zerohop(config, "MyPrivateChannel") is True
-
-    def test_whitelist_with_entries_passes_through(self):
+    def test_enabled_and_channel_in_set_zerohops(self):
         config = {
-            "channel_policy": "whitelist",
-            "_whitelist_set": {"PrivateChannel", "MyGroup"},
-            "_blacklist_set": set(),
+            "zerohop_enabled": True,
+            "_zerohop_channels_set": {"LongFast", "ShortFast"},
         }
         assert should_zerohop(config, "LongFast") is True
-        assert should_zerohop(config, "PrivateChannel") is False
-        assert should_zerohop(config, "MyGroup") is False
+        assert should_zerohop(config, "ShortFast") is True
 
-    def test_blacklist_zerohops_listed(self):
+    def test_enabled_but_channel_not_in_set_passes_through(self):
         config = {
-            "channel_policy": "blacklist",
-            "_whitelist_set": set(),
-            "_blacklist_set": {"LongFast", "ShortFast"},
+            "zerohop_enabled": True,
+            "_zerohop_channels_set": {"LongFast"},
         }
-        assert should_zerohop(config, "LongFast") is True
         assert should_zerohop(config, "MyPrivate") is False
 
-    def test_blacklist_empty_zerohops_none(self):
-        config = {"channel_policy": "blacklist", "_whitelist_set": set(), "_blacklist_set": set()}
+    def test_disabled_never_zerohops(self):
+        config = {
+            "zerohop_enabled": False,
+            "_zerohop_channels_set": {"LongFast"},
+        }
         assert should_zerohop(config, "LongFast") is False
 
-    def test_unknown_policy_defaults_to_zerohop(self):
-        config = {"channel_policy": "invalid", "_whitelist_set": set(), "_blacklist_set": set()}
-        assert should_zerohop(config, "anything") is True
+    def test_empty_channel_set_never_zerohops(self):
+        config = {"zerohop_enabled": True, "_zerohop_channels_set": set()}
+        assert should_zerohop(config, "LongFast") is False
+
+    def test_default_enabled_when_key_missing(self):
+        # Belt and suspenders: should_zerohop defaults zerohop_enabled to True
+        # so a malformed config still applies the channel filter.
+        config = {"_zerohop_channels_set": {"LongFast"}}
+        assert should_zerohop(config, "LongFast") is True
 
 
-class TestLoadConfig:
+# ---------------------------------------------------------------------------
+# should_drop
+# ---------------------------------------------------------------------------
 
-    def test_default_config(self):
-        config = load_config(None)
-        assert config["channel_policy"] == "blacklist"
-        assert config["channel_whitelist"] == []
-        assert len(config["channel_blacklist"]) == 8
-        assert config["grpc_port"] == 9000
-        assert config["stats_interval_s"] == 60
+class TestShouldDrop:
+
+    def _config(self, *, enabled=True, drop_channels=None, drop_portnums=("RANGE_TEST_APP",)):
+        return {
+            "drop_enabled": enabled,
+            "_drop_channels_set": drop_channels,
+            "_drop_portnums_set": set(drop_portnums),
+        }
+
+    def test_disabled_never_drops(self):
+        config = self._config(enabled=False, drop_channels={"LongFast"})
+        assert should_drop(config, "LongFast", "RANGE_TEST_APP") is False
+
+    def test_match_channel_and_portnum_drops(self):
+        config = self._config(drop_channels={"LongFast"})
+        assert should_drop(config, "LongFast", "RANGE_TEST_APP") is True
+
+    def test_portnum_not_in_set_does_not_drop(self):
+        config = self._config(drop_channels={"LongFast"})
+        assert should_drop(config, "LongFast", "TEXT_MESSAGE_APP") is False
+
+    def test_channel_not_in_set_does_not_drop(self):
+        config = self._config(drop_channels={"LongFast"})
+        assert should_drop(config, "MyPrivate", "RANGE_TEST_APP") is False
+
+    def test_unknown_portnum_never_drops(self):
+        # When floodgate can't read the portnum (custom-keyed channel,
+        # unrecognized JSON type), the policy errs on deliver.
+        config = self._config(drop_channels={"LongFast"})
+        assert should_drop(config, "LongFast", None) is False
+
+    def test_drop_channels_none_means_all_channels(self):
+        config = self._config(drop_channels=None)
+        assert should_drop(config, "LongFast",  "RANGE_TEST_APP") is True
+        assert should_drop(config, "AnyChannel", "RANGE_TEST_APP") is True
+
+
+# ---------------------------------------------------------------------------
+# load_config — defaults and basic merge
+# ---------------------------------------------------------------------------
+
+class TestLoadConfigDefaults:
+
+    def test_default_zerohop_enabled_true(self):
+        cfg = load_config(None)
+        assert cfg["zerohop_enabled"] is True
+
+    def test_default_zerohop_channels_eight_presets(self):
+        cfg = load_config(None)
+        assert len(cfg["zerohop_channels"]) == 8
+        assert "LongFast" in cfg["zerohop_channels"]
+
+    def test_default_drop_disabled(self):
+        cfg = load_config(None)
+        assert cfg["drop_enabled"] is False
+
+    def test_default_drop_channels_inherits(self):
+        cfg = load_config(None)
+        assert cfg["drop_channels"] == INHERIT_ZEROHOP_CHANNELS
+
+    def test_default_drop_portnums_empty(self):
+        cfg = load_config(None)
+        assert cfg["drop_portnums"] == []
+
+    def test_default_grpc_port(self):
+        assert load_config(None)["grpc_port"] == 9000
+
+    def test_default_health_port(self):
+        assert load_config(None)["health_port"] == 8080
+
+    def test_default_log_format_is_text(self):
+        assert load_config(None)["log_format"] == "text"
+
+    def test_precomputed_zerohop_set_matches_list(self):
+        cfg = load_config(None)
+        assert cfg["_zerohop_channels_set"] == set(cfg["zerohop_channels"])
+
+    def test_precomputed_drop_set_inherits_zerohop_set(self):
+        cfg = load_config(None)
+        assert cfg["_drop_channels_set"] == cfg["_zerohop_channels_set"]
+
+    def test_precomputed_drop_portnums_empty_set(self):
+        assert load_config(None)["_drop_portnums_set"] == set()
+
+
+class TestLoadConfigFromFile:
 
     def test_load_from_file(self, tmp_path):
         cfg_file = tmp_path / "config.yaml"
-        cfg_file.write_text(yaml.dump({"channel_policy": "blacklist", "grpc_port": 8080}))
-        config = load_config(str(cfg_file))
-        assert config["channel_policy"] == "blacklist"
-        assert config["grpc_port"] == 8080
-        assert "channel_whitelist" in config
-        assert "stats_interval_s" in config
+        cfg_file.write_text(yaml.dump({"zerohop_enabled": False, "grpc_port": 8080}))
+        cfg = load_config(str(cfg_file))
+        assert cfg["zerohop_enabled"] is False
+        assert cfg["grpc_port"] == 8080
+        # untouched defaults still present
+        assert cfg["health_port"] == 8080
+        assert cfg["stats_interval_s"] == 60
 
     def test_load_from_env(self, tmp_path, monkeypatch):
         cfg_file = tmp_path / "config.yaml"
-        cfg_file.write_text(yaml.dump({"channel_policy": "blacklist"}))
+        cfg_file.write_text(yaml.dump({"zerohop_enabled": False}))
         monkeypatch.setenv("FLOODGATE_CONFIG", str(cfg_file))
-        config = load_config(None)
-        assert config["channel_policy"] == "blacklist"
+        cfg = load_config(None)
+        assert cfg["zerohop_enabled"] is False
 
     def test_missing_file_uses_defaults(self):
-        config = load_config("/nonexistent/config.yaml")
-        assert config["channel_policy"] == "blacklist"
-
-    def test_sets_are_computed(self):
-        config = load_config(None)
-        assert isinstance(config["_whitelist_set"], set)
-        assert isinstance(config["_blacklist_set"], set)
-
-    def test_stats_interval_override(self, tmp_path):
-        cfg_file = tmp_path / "config.yaml"
-        cfg_file.write_text(yaml.dump({"stats_interval_s": 300}))
-        config = load_config(str(cfg_file))
-        assert config["stats_interval_s"] == 300
-
-    def test_default_log_format(self):
-        config = load_config(None)
-        assert config["log_format"] == "text"
+        cfg = load_config("/nonexistent/config.yaml")
+        assert cfg["zerohop_enabled"] is True
+        assert len(cfg["zerohop_channels"]) == 8
 
     def test_log_format_from_yaml(self, tmp_path):
         cfg_file = tmp_path / "config.yaml"
         cfg_file.write_text(yaml.dump({"log_format": "json"}))
-        config = load_config(str(cfg_file))
-        assert config["log_format"] == "json"
+        assert load_config(str(cfg_file))["log_format"] == "json"
 
     def test_log_format_env_overrides_yaml(self, tmp_path, monkeypatch):
         cfg_file = tmp_path / "config.yaml"
         cfg_file.write_text(yaml.dump({"log_format": "text"}))
         monkeypatch.setenv("FLOODGATE_LOG_FORMAT", "json")
-        config = load_config(str(cfg_file))
-        assert config["log_format"] == "json"
+        assert load_config(str(cfg_file))["log_format"] == "json"
+
+    def test_user_zerohop_channels_replaces_default(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(yaml.dump({"zerohop_channels": ["MyChannel"]}))
+        cfg = load_config(str(cfg_file))
+        assert cfg["zerohop_channels"] == ["MyChannel"]
+        assert cfg["_zerohop_channels_set"] == {"MyChannel"}
+
+
+# ---------------------------------------------------------------------------
+# Removed-key rejection
+# ---------------------------------------------------------------------------
+
+class TestRemovedKeysRejected:
+
+    @pytest.mark.parametrize("key,value", [
+        ("channel_policy",    "blacklist"),
+        ("channel_blacklist", ["LongFast"]),
+        ("channel_whitelist", []),
+    ])
+    def test_each_removed_key_raises(self, tmp_path, key, value):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(yaml.dump({key: value}))
+        with pytest.raises(ConfigError) as exc:
+            load_config(str(cfg_file))
+        assert key in str(exc.value)
+
+    def test_error_message_lists_all_removed_keys_present(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(yaml.dump({
+            "channel_policy":    "blacklist",
+            "channel_whitelist": [],
+        }))
+        with pytest.raises(ConfigError) as exc:
+            load_config(str(cfg_file))
+        msg = str(exc.value)
+        assert "channel_policy"    in msg
+        assert "channel_whitelist" in msg
+
+
+# ---------------------------------------------------------------------------
+# drop_channels resolution
+# ---------------------------------------------------------------------------
+
+class TestDropChannelsResolution:
+
+    def test_inherits_zerohop_channels_via_sentinel_string(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(yaml.dump({
+            "zerohop_channels": ["LongFast", "MediumFast"],
+            "drop_channels":    INHERIT_ZEROHOP_CHANNELS,
+        }))
+        cfg = load_config(str(cfg_file))
+        assert cfg["_drop_channels_set"] == {"LongFast", "MediumFast"}
+
+    def test_explicit_list(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(yaml.dump({
+            "zerohop_channels": ["LongFast"],
+            "drop_channels":    ["MediumFast", "ShortFast"],
+        }))
+        cfg = load_config(str(cfg_file))
+        assert cfg["_drop_channels_set"] == {"MediumFast", "ShortFast"}
+
+    def test_null_means_all_channels(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text("drop_channels: null\nzerohop_channels: ['LongFast']\n")
+        cfg = load_config(str(cfg_file))
+        assert cfg["_drop_channels_set"] is None
+
+    def test_empty_list_means_all_channels(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(yaml.dump({"drop_channels": []}))
+        cfg = load_config(str(cfg_file))
+        assert cfg["_drop_channels_set"] is None
+
+    def test_invalid_string_raises(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(yaml.dump({"drop_channels": "something_else"}))
+        with pytest.raises(ConfigError):
+            load_config(str(cfg_file))
+
+    def test_invalid_type_raises(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(yaml.dump({"drop_channels": 42}))
+        with pytest.raises(ConfigError):
+            load_config(str(cfg_file))
+
+
+# ---------------------------------------------------------------------------
+# drop_portnums set
+# ---------------------------------------------------------------------------
+
+class TestDropPortnums:
+
+    def test_user_list_becomes_set(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(yaml.dump({
+            "drop_portnums": ["RANGE_TEST_APP", "TELEMETRY_APP"],
+        }))
+        cfg = load_config(str(cfg_file))
+        assert cfg["_drop_portnums_set"] == {"RANGE_TEST_APP", "TELEMETRY_APP"}
+
+    def test_yaml_null_becomes_empty_set(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text("drop_portnums:\n")
+        cfg = load_config(str(cfg_file))
+        assert cfg["_drop_portnums_set"] == set()
+
+
+# ---------------------------------------------------------------------------
+# String-list validation (catches numeric portnum IDs, etc.)
+# ---------------------------------------------------------------------------
+
+class TestStringListValidation:
+    """A user typing `drop_portnums: [66]` (the numeric portnum) instead of
+    `["RANGE_TEST_APP"]` would silently never match without this check."""
+
+    def test_drop_portnums_with_int_entry_raises(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(yaml.dump({"drop_portnums": [66, "TELEMETRY_APP"]}))
+        with pytest.raises(ConfigError) as exc:
+            load_config(str(cfg_file))
+        assert "drop_portnums" in str(exc.value)
+        assert "66"            in str(exc.value)
+
+    def test_drop_channels_with_int_entry_raises(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(yaml.dump({"drop_channels": [42, "LongFast"]}))
+        with pytest.raises(ConfigError) as exc:
+            load_config(str(cfg_file))
+        assert "drop_channels" in str(exc.value)
+
+    def test_zerohop_channels_with_int_entry_raises(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(yaml.dump({"zerohop_channels": [1, "LongFast"]}))
+        with pytest.raises(ConfigError) as exc:
+            load_config(str(cfg_file))
+        assert "zerohop_channels" in str(exc.value)
+
+    def test_zerohop_channels_not_a_list_raises(self, tmp_path):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(yaml.dump({"zerohop_channels": "LongFast"}))
+        with pytest.raises(ConfigError):
+            load_config(str(cfg_file))

--- a/tests/test_container_smoke.py
+++ b/tests/test_container_smoke.py
@@ -112,7 +112,8 @@ class TestContainerSmoke:
         _, body = _wait_for_health(f"http://localhost:{HEALTH_PORT}/health")
         data = json.loads(body)
         stats = data["stats"]
-        for key in ("zerohop", "passthru", "noop", "skipped", "errors", "total"):
+        for key in ("zerohop", "passthru", "noop", "dropped",
+                    "skipped", "errors", "total"):
             assert key in stats, f"missing stats key: {key}"
 
     def test_unknown_path_returns_404(self, running_container):

--- a/tests/test_decrypt.py
+++ b/tests/test_decrypt.py
@@ -1,0 +1,108 @@
+"""Tests for AES-128-CTR Meshtastic decryption."""
+
+import pytest
+
+from floodgate.decrypt import DEFAULT_KEY, build_nonce, decrypt
+
+
+class TestBuildNonce:
+
+    def test_layout_packet_id_first_then_from_then_zero_padding(self):
+        # packet_id = 0x0807060504030201, from = 0x0c0b0a09
+        nonce = build_nonce(0x0807060504030201, 0x0C0B0A09)
+        assert nonce == bytes.fromhex(
+            "0102030405060708"   # packet_id LE
+            "090a0b0c"           # from LE
+            "00000000"           # extra_nonce
+        )
+
+    def test_length_is_16_bytes(self):
+        assert len(build_nonce(1, 1)) == 16
+
+    def test_zero_inputs(self):
+        assert build_nonce(0, 0) == b"\x00" * 16
+
+    def test_max_uint64_packet_id(self):
+        nonce = build_nonce(0xFFFFFFFFFFFFFFFF, 0)
+        assert nonce[:8] == b"\xff" * 8
+        assert nonce[8:] == b"\x00" * 8
+
+    def test_max_uint32_from_node(self):
+        nonce = build_nonce(0, 0xFFFFFFFF)
+        assert nonce[:8] == b"\x00" * 8
+        assert nonce[8:12] == b"\xff" * 4
+        assert nonce[12:] == b"\x00" * 4
+
+
+class TestDefaultKey:
+
+    def test_length_is_16_bytes_aes128(self):
+        assert len(DEFAULT_KEY) == 16
+
+    def test_canonical_value(self):
+        # Documented Meshtastic default key — fixed forever, do not change.
+        assert DEFAULT_KEY.hex() == "d4f1bb3a20290759f0bcffabcf4e6901"
+
+
+class TestDecryptRoundtrip:
+    """AES-CTR is symmetric — same function encrypts and decrypts."""
+
+    def test_roundtrip_default_key(self):
+        plaintext = b"hello meshtastic world"
+        ct = decrypt(plaintext, packet_id=12345, from_node=0xDEADBEEF)
+        assert ct != plaintext   # actually encrypted
+        pt = decrypt(ct, packet_id=12345, from_node=0xDEADBEEF)
+        assert pt == plaintext
+
+    def test_roundtrip_explicit_key(self):
+        key = b"\x42" * 16
+        plaintext = b"some data"
+        ct = decrypt(plaintext, packet_id=1, from_node=2, key=key)
+        pt = decrypt(ct, packet_id=1, from_node=2, key=key)
+        assert pt == plaintext
+
+    def test_empty_input_returns_empty(self):
+        assert decrypt(b"", packet_id=1, from_node=1) == b""
+
+    def test_wrong_key_produces_garbage_no_exception(self):
+        plaintext = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09"
+        ct = decrypt(plaintext, packet_id=1, from_node=1, key=DEFAULT_KEY)
+        wrong_key = b"\x99" * 16
+        garbage = decrypt(ct, packet_id=1, from_node=1, key=wrong_key)
+        assert garbage != plaintext
+        assert len(garbage) == len(plaintext)
+
+    def test_different_nonce_different_ciphertext(self):
+        plaintext = b"same plaintext"
+        ct1 = decrypt(plaintext, packet_id=1, from_node=1)
+        ct2 = decrypt(plaintext, packet_id=2, from_node=1)
+        assert ct1 != ct2
+
+
+class TestDecryptRealMeshtasticInterop:
+    """Decrypt a Data protobuf encrypted with the canonical Meshtastic
+    parameters and verify it parses back to the original portnum.
+
+    This is the integration check that pins our implementation to the
+    upstream firmware behavior — if Meshtastic ever changes the nonce
+    layout, AES variant, or default key, this test fails.
+    """
+
+    def test_roundtrip_through_data_protobuf(self):
+        pytest.importorskip("meshtastic")
+        from meshtastic import mesh_pb2, portnums_pb2
+
+        original = mesh_pb2.Data()
+        original.portnum = portnums_pb2.PortNum.RANGE_TEST_APP
+        original.payload = b"seq 42"
+
+        packet_id, from_node = 0xABCDEF01, 0x12345678
+        ciphertext = decrypt(
+            original.SerializeToString(),
+            packet_id=packet_id, from_node=from_node,
+        )
+
+        recovered = mesh_pb2.Data()
+        recovered.ParseFromString(decrypt(ciphertext, packet_id, from_node))
+        assert recovered.portnum == portnums_pb2.PortNum.RANGE_TEST_APP
+        assert recovered.payload == b"seq 42"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -40,12 +40,8 @@ class TestHealthEndpoint:
     def setup_method(self):
         # Reset both rolling and lifetime counters before each test
         with packet_stats._lock:
-            packet_stats.zerohop = 0
-            packet_stats.passthru = 0
-            packet_stats.noop = 0
-            packet_stats.skipped = 0
-            packet_stats.errors = 0
-            for k in packet_stats._lifetime:
+            for k in ("zerohop", "passthru", "noop", "dropped", "skipped", "errors"):
+                setattr(packet_stats, k, 0)
                 packet_stats._lifetime[k] = 0
 
     def test_health_returns_200(self):
@@ -79,8 +75,17 @@ class TestHealthEndpoint:
             _, body = _get(f"{base}/health")
             data = json.loads(body)
             stats = data["stats"]
-            for key in ("zerohop", "passthru", "noop", "skipped", "errors", "total"):
+            for key in ("zerohop", "passthru", "noop", "dropped",
+                        "skipped", "errors", "total"):
                 assert key in stats, f"missing key: {key}"
+        finally:
+            server.shutdown()
+
+    def test_health_body_dropped_starts_at_zero(self):
+        server, base = _start_test_server()
+        try:
+            _, body = _get(f"{base}/health")
+            assert json.loads(body)["stats"]["dropped"] == 0
         finally:
             server.shutdown()
 

--- a/tests/test_log_setup.py
+++ b/tests/test_log_setup.py
@@ -85,11 +85,13 @@ class TestStructuredTextFormatter:
     def test_stats_event_renders_stats_tag(self):
         output = self._format(
             "stats", event="stats", interval_s=60,
-            zerohop=5, passthru=1, noop=0, skipped=10, errors=0, total=16,
+            zerohop=5, passthru=1, noop=0, dropped=2, skipped=10,
+            errors=0, total=18,
         )
         assert "[STATS]" in output
         assert "zerohop=5" in output
-        assert "total=16" in output
+        assert "dropped=2" in output
+        assert "total=18" in output
 
     def test_plain_message_passes_through(self):
         output = self._format("ExHook gRPC server listening on port 9000")
@@ -178,17 +180,29 @@ class TestJsonFormatterSnapshots:
     def test_stats_event_fields(self):
         data = self._format_json(
             "stats", event="stats",
-            interval_s=60, zerohop=142, passthru=1, noop=0,
-            skipped=1050, errors=0, total=1193,
+            interval_s=60, zerohop=142, passthru=1, noop=0, dropped=4,
+            skipped=1050, errors=0, total=1197,
         )
-        assert data["event"] == "stats"
+        assert data["event"]      == "stats"
         assert data["interval_s"] == 60
-        assert data["zerohop"] == 142
-        assert data["passthru"] == 1
-        assert data["noop"] == 0
-        assert data["skipped"] == 1050
-        assert data["errors"] == 0
-        assert data["total"] == 1193
+        assert data["zerohop"]    == 142
+        assert data["passthru"]   == 1
+        assert data["noop"]       == 0
+        assert data["dropped"]    == 4
+        assert data["skipped"]    == 1050
+        assert data["errors"]     == 0
+        assert data["total"]      == 1197
+
+    def test_dropped_message_fields(self):
+        data = self._format_json(
+            "dropped", event="message", outcome="dropped",
+            topic="msh/US/2/e/LongFast/!1234", channel="LongFast",
+            encoding="e", portnum="RANGE_TEST_APP", id="0x12345678",
+            **{"from": "!abcd1234", "to": "!ffffffff"},
+        )
+        assert data["outcome"] == "dropped"
+        assert data["portnum"] == "RANGE_TEST_APP"
+        assert data["channel"] == "LongFast"
 
     def test_timestamp_format_iso8601(self):
         data = self._format_json("ts check")
@@ -245,6 +259,20 @@ class TestTextFormatterSnapshots:
         assert "[floodgate.zerohop]" in output
         assert "INFO" in output
 
+    def test_dropped_exact_output_includes_portnum(self):
+        output = self._format_text(
+            "dropped", event="message", outcome="dropped",
+            topic="msh/US/2/e/LongFast/!1234", channel="LongFast",
+            encoding="e", portnum="RANGE_TEST_APP", id="0x12345678",
+            **{"from": "!abcd1234", "to": "!ffffffff"},
+        )
+        expected_tail = (
+            "[DROPPED] topic=msh/US/2/e/LongFast/!1234 channel=LongFast"
+            " encoding=e portnum=RANGE_TEST_APP id=0x12345678"
+            " from=!abcd1234 to=!ffffffff"
+        )
+        assert output.endswith(expected_tail)
+
     def test_noop_exact_output(self):
         output = self._format_text(
             "noop", event="message", outcome="noop",
@@ -284,12 +312,12 @@ class TestTextFormatterSnapshots:
     def test_stats_exact_field_order(self):
         output = self._format_text(
             "stats", event="stats",
-            interval_s=60, zerohop=142, passthru=1, noop=0,
-            skipped=1050, errors=0, total=1193,
+            interval_s=60, zerohop=142, passthru=1, noop=0, dropped=4,
+            skipped=1050, errors=0, total=1197,
         )
         expected_tail = (
             "[STATS] interval_s=60 zerohop=142 passthru=1"
-            " noop=0 skipped=1050 errors=0 total=1193"
+            " noop=0 dropped=4 skipped=1050 errors=0 total=1197"
         )
         assert output.endswith(expected_tail)
 

--- a/tests/test_portnum.py
+++ b/tests/test_portnum.py
@@ -1,0 +1,168 @@
+"""Tests for portnum extraction from /e/ and /json/ payloads."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from floodgate.decrypt import decrypt
+from floodgate.portnum import extract_portnum_json, extract_portnum_protobuf
+
+PAYLOADS_DIR = Path(__file__).parent / "payloads"
+PROTOBUF_PAYLOADS_DIR = PAYLOADS_DIR / "protobuf"
+
+
+# ---------------------------------------------------------------------------
+# JSON extraction
+# ---------------------------------------------------------------------------
+
+class TestExtractPortnumJson:
+
+    # File → expected portnum enum name. Pinned to real fixtures so any
+    # parser regression that misclassifies a real-world payload fails here.
+    EXPECTED = {
+        "text_message.json":         "TEXT_MESSAGE_APP",
+        "position.json":             "POSITION_APP",
+        "nodeinfo.json":             "NODEINFO_APP",
+        "device_metrics.json":       "TELEMETRY_APP",
+        "environment_metrics.json":  "TELEMETRY_APP",
+        "neighborinfo.json":         "NEIGHBORINFO_APP",
+        "traceroute.json":           "TRACEROUTE_APP",
+        "range_test_app.json":       "RANGE_TEST_APP",
+    }
+
+    @pytest.mark.parametrize("filename,expected", sorted(EXPECTED.items()))
+    def test_real_world_fixture(self, filename, expected):
+        path = PAYLOADS_DIR / filename
+        result = extract_portnum_json(path.read_bytes())
+        assert result == expected, f"{filename}: got {result!r}, want {expected!r}"
+
+    def test_invalid_json_returns_none(self):
+        assert extract_portnum_json(b"not json {{") is None
+
+    def test_empty_bytes_returns_none(self):
+        assert extract_portnum_json(b"") is None
+
+    def test_top_level_array_returns_none(self):
+        assert extract_portnum_json(b"[1, 2, 3]") is None
+
+    def test_unknown_type_returns_none(self):
+        payload = json.dumps({"type": "made_up_thing"}).encode()
+        assert extract_portnum_json(payload) is None
+
+    def test_explicit_top_level_portnum_field(self):
+        # Some senders put portnum at the top level directly.
+        payload = json.dumps({"portnum": "ADMIN_APP"}).encode()
+        assert extract_portnum_json(payload) == "ADMIN_APP"
+
+    def test_nested_decoded_portnum_wins_over_type(self):
+        # Wrapper packet form: `type` is "packet", real portnum nested deep.
+        payload = json.dumps({
+            "type": "packet",
+            "payload": {"decoded": {"portnum": "RANGE_TEST_APP"}},
+        }).encode()
+        assert extract_portnum_json(payload) == "RANGE_TEST_APP"
+
+    def test_payload_field_not_dict_falls_through(self):
+        # E.g. payload is a string, not a wrapper dict — fall through to type.
+        payload = json.dumps({"type": "text", "payload": "raw string"}).encode()
+        assert extract_portnum_json(payload) == "TEXT_MESSAGE_APP"
+
+    def test_type_case_insensitive(self):
+        payload = json.dumps({"type": "TEXT"}).encode()
+        assert extract_portnum_json(payload) == "TEXT_MESSAGE_APP"
+
+
+# ---------------------------------------------------------------------------
+# Protobuf extraction — synthetic envelopes only.
+#
+# The captured `tests/payloads/protobuf/*.bin` fixtures were anonymized
+# (sender IDs rewritten), which breaks the AES-CTR nonce relationship and
+# makes their original ciphertext non-decryptable. We build fresh synthetic
+# envelopes encrypted under the default key for these tests.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def meshtastic_pb2():
+    pytest.importorskip("meshtastic")
+    from meshtastic import mesh_pb2, mqtt_pb2, portnums_pb2
+    return mesh_pb2, mqtt_pb2, portnums_pb2
+
+
+def _build_encrypted_envelope(mesh_pb2, mqtt_pb2, portnum, payload_bytes,
+                              packet_id=0xAABBCCDD, from_node=0x12345678,
+                              channel_name="LongFast"):
+    """Construct a ServiceEnvelope whose inner MeshPacket has the named
+    portnum encrypted under the default Meshtastic key."""
+    data = mesh_pb2.Data()
+    data.portnum = portnum
+    data.payload = payload_bytes
+    ciphertext = decrypt(data.SerializeToString(),
+                         packet_id=packet_id, from_node=from_node)
+
+    pkt = mesh_pb2.MeshPacket()
+    pkt.id = packet_id
+    setattr(pkt, pkt.DESCRIPTOR.fields_by_name["from"].name, from_node)
+    pkt.encrypted = ciphertext
+
+    env = mqtt_pb2.ServiceEnvelope()
+    env.packet.CopyFrom(pkt)
+    env.channel_id = channel_name
+    return env.SerializeToString()
+
+
+class TestExtractPortnumProtobuf:
+
+    def test_synthetic_range_test_packet(self, meshtastic_pb2):
+        mesh_pb2, mqtt_pb2, portnums_pb2 = meshtastic_pb2
+        envelope = _build_encrypted_envelope(
+            mesh_pb2, mqtt_pb2,
+            portnum=portnums_pb2.PortNum.RANGE_TEST_APP,
+            payload_bytes=b"seq 7",
+        )
+        assert extract_portnum_protobuf(envelope) == "RANGE_TEST_APP"
+
+    def test_synthetic_text_message(self, meshtastic_pb2):
+        mesh_pb2, mqtt_pb2, portnums_pb2 = meshtastic_pb2
+        envelope = _build_encrypted_envelope(
+            mesh_pb2, mqtt_pb2,
+            portnum=portnums_pb2.PortNum.TEXT_MESSAGE_APP,
+            payload_bytes=b"hi",
+        )
+        assert extract_portnum_protobuf(envelope) == "TEXT_MESSAGE_APP"
+
+    def test_unparseable_bytes_returns_none(self):
+        assert extract_portnum_protobuf(b"\x00\x01\x02 nonsense") is None
+
+    def test_empty_bytes_returns_none(self):
+        assert extract_portnum_protobuf(b"") is None
+
+    def test_envelope_without_packet_returns_none(self, meshtastic_pb2):
+        _, mqtt_pb2, _ = meshtastic_pb2
+        env = mqtt_pb2.ServiceEnvelope()
+        env.channel_id = "LongFast"
+        # No packet field set
+        assert extract_portnum_protobuf(env.SerializeToString()) is None
+
+    def test_packet_with_decoded_variant_returns_none(self, meshtastic_pb2):
+        mesh_pb2, mqtt_pb2, portnums_pb2 = meshtastic_pb2
+        # Already-decoded packet (no encryption) — drop filter doesn't act on these.
+        pkt = mesh_pb2.MeshPacket()
+        pkt.decoded.portnum = portnums_pb2.PortNum.TEXT_MESSAGE_APP
+        env = mqtt_pb2.ServiceEnvelope()
+        env.packet.CopyFrom(pkt)
+        assert extract_portnum_protobuf(env.SerializeToString()) is None
+
+    def test_anonymized_real_fixtures_dont_crash(self, meshtastic_pb2):
+        """The captured `.bin` fixtures were anonymized (from-field rewritten),
+        so AES-CTR decryption with the default key produces garbage. The
+        function must return None gracefully — no exceptions, no crashes."""
+        if not PROTOBUF_PAYLOADS_DIR.exists():
+            pytest.skip("no protobuf fixtures present")
+        for path in sorted(PROTOBUF_PAYLOADS_DIR.glob("*.bin")):
+            result = extract_portnum_protobuf(path.read_bytes())
+            # We don't assert what it returns — only that it doesn't raise.
+            # In practice every anonymized fixture decrypts to garbage and
+            # returns None, but a chance hash-collision could land on a valid
+            # Data parse. Either way: never an exception.
+            assert result is None or isinstance(result, str)

--- a/tests/test_zerohop.py
+++ b/tests/test_zerohop.py
@@ -1,4 +1,4 @@
-"""Tests for core zero-hop packet processing logic."""
+"""Tests for the per-message processing pipeline (drop, zerohop, logging)."""
 
 import json
 import logging
@@ -8,19 +8,24 @@ from unittest.mock import patch
 import pytest
 
 from floodgate.zerohop import (
+    ACTION_DROP,
+    ACTION_MODIFY,
+    ACTION_PASSTHRU,
     _fmt_node,
     _peek_meta,
     parse_meshtastic_topic,
     process_message,
     zerohop_json,
 )
+from floodgate.zerohop import stats as packet_stats
 
-# Directory of real-world Meshtastic JSON payloads captured from gateways.
-# Each file is the raw JSON exactly as published on /json/ topics. Drop new
-# samples in to extend coverage — they're picked up automatically by the
-# parametrized smoke test, and individual tests can load them by filename
-# for detailed assertions.
-PAYLOADS_DIR = Path(__file__).parent / "payloads"
+# Directory of real-world Meshtastic payloads captured from gateways.
+# Each JSON file is the raw form exactly as published on /json/ topics; each
+# .bin under protobuf/ is a captured ServiceEnvelope. Drop new samples in to
+# extend coverage — they're picked up automatically by the parametrized
+# smoke tests, and individual tests can load them by filename for detailed
+# assertions.
+PAYLOADS_DIR          = Path(__file__).parent / "payloads"
 PROTOBUF_PAYLOADS_DIR = PAYLOADS_DIR / "protobuf"
 
 
@@ -38,6 +43,28 @@ def _load_json_payload(name):
     return (PAYLOADS_DIR / name).read_bytes()
 
 
+def _make_config(*, zerohop_enabled=True, zerohop_channels=(),
+                 drop_enabled=False, drop_channels=None, drop_portnums=()):
+    """Build a fully-resolved config dict (with the precomputed sets that
+    load_config would otherwise produce). Tests skip load_config to keep
+    individual cases tight and explicit."""
+    zerohop_set = set(zerohop_channels)
+    return {
+        "zerohop_enabled":         zerohop_enabled,
+        "zerohop_channels":        list(zerohop_channels),
+        "_zerohop_channels_set":   zerohop_set,
+        "drop_enabled":            drop_enabled,
+        "drop_channels":           drop_channels,
+        "_drop_channels_set":      set(drop_channels) if drop_channels else None,
+        "drop_portnums":           list(drop_portnums),
+        "_drop_portnums_set":      set(drop_portnums),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers
+# ---------------------------------------------------------------------------
+
 class TestFmtNode:
 
     def test_int_node_id(self):
@@ -53,7 +80,7 @@ class TestFmtNode:
         assert _fmt_node("!f6acb04f") == "!f6acb04f"
 
 
-class TestParseMetastasticTopic:
+class TestParseMeshtasticTopic:
 
     def test_protobuf_topic_returns_channel_and_encoding(self):
         assert parse_meshtastic_topic("msh/US/2/e/LongFast/!12345678") == ("LongFast", "e")
@@ -102,6 +129,10 @@ class TestParseMetastasticTopic:
         assert parse_meshtastic_topic("msh/US/2/xml/LongFast/!deadbeef") is None
 
 
+# ---------------------------------------------------------------------------
+# zerohop_json
+# ---------------------------------------------------------------------------
+
 class TestZerohopJson:
 
     def _payload(self, **kwargs):
@@ -119,43 +150,41 @@ class TestZerohopJson:
         return json.dumps(data).encode()
 
     def test_sets_hop_limit_to_zero_explicit(self):
-        modified, old_hop, meta = zerohop_json(self._payload(hop_limit=3))
+        modified, old_hop, _ = zerohop_json(self._payload(hop_limit=3))
         assert old_hop == 3
         assert modified is not None
         assert json.loads(modified)["hop_limit"] == 0
 
     def test_uses_hops_away_when_no_hop_limit(self):
-        # Meshtastic JSON omits hop_limit, uses hop_start and hops_away
-        modified, old_hop, meta = zerohop_json(self._payload_meshtastic(hop_start=5, hops_away=0))
+        modified, old_hop, _ = zerohop_json(self._payload_meshtastic(hop_start=5, hops_away=0))
         assert old_hop == 5   # effective: hop_start(5) - hops_away(0)
         assert modified is not None
         assert json.loads(modified)["hop_limit"] == 0
 
     def test_hops_away_equals_hop_start_is_noop(self):
-        # hop_start=5, hops_away=5 → effective hop_limit=0 → already zerohoped
-        modified, old_hop, meta = zerohop_json(self._payload_meshtastic(hop_start=5, hops_away=5))
+        modified, old_hop, _ = zerohop_json(self._payload_meshtastic(hop_start=5, hops_away=5))
         assert modified is None
         assert old_hop == 0
 
     def test_noop_when_explicit_hop_limit_zero(self):
-        modified, old_hop, meta = zerohop_json(self._payload(hop_limit=0))
+        modified, old_hop, _ = zerohop_json(self._payload(hop_limit=0))
         assert modified is None
         assert old_hop == 0
 
     def test_extracts_metadata(self):
         _, _, meta = zerohop_json(self._payload(hop_limit=5, hop_start=5, via_mqtt=True))
-        assert meta["sender"] == 305419896
+        assert meta["sender"]      == 305419896
         assert meta["destination"] == 4294967295
-        assert meta["packet_id"] == 12345
-        assert meta["hop_start"] == 5
-        assert meta["via_mqtt"] is True
+        assert meta["packet_id"]   == 12345
+        assert meta["hop_start"]   == 5
+        assert meta["via_mqtt"]    is True
 
     def test_packet_id_in_meta_is_decimal(self):
         _, _, meta = zerohop_json(self._payload_meshtastic())
         assert meta["packet_id"] == 1700391097  # decimal, not hex
 
     def test_parse_error_returns_none_none(self):
-        modified, old_hop, meta = zerohop_json(b"not json at all")
+        modified, old_hop, _ = zerohop_json(b"not json at all")
         assert modified is None
         assert old_hop is None
 
@@ -163,8 +192,7 @@ class TestZerohopJson:
         """JSON payloads may have string node IDs instead of integers."""
         data = {"from": "!f6acb04f", "to": "!ffffffff", "id": 12345,
                 "hop_limit": 3, "hop_start": 3}
-        payload = json.dumps(data).encode()
-        modified, old_hop, meta = zerohop_json(payload)
+        modified, old_hop, meta = zerohop_json(json.dumps(data).encode())
         assert old_hop == 3
         assert modified is not None
         assert meta["sender"] == "!f6acb04f"
@@ -172,98 +200,80 @@ class TestZerohopJson:
     def test_preserves_other_fields(self):
         modified, _, _ = zerohop_json(self._payload(hop_limit=3))
         data = json.loads(modified)
-        assert data["type"] == "text"
+        assert data["type"]    == "text"
         assert data["channel"] == 0
 
 
+# ---------------------------------------------------------------------------
+# process_message — routing logic with mocked zerohop functions
+# ---------------------------------------------------------------------------
+
 class TestProcessMessage:
-    """Test process_message routing logic using mocked zerohop functions."""
 
-    def _config(self, policy="whitelist", whitelist=None, blacklist=None):
-        return {
-            "channel_policy": policy,
-            "_whitelist_set": set(whitelist or []),
-            "_blacklist_set": set(blacklist or []),
-            "channel_whitelist": whitelist or [],
-            "channel_blacklist": blacklist or [],
-        }
-
-    def test_non_meshtastic_topic_ignored(self):
-        config = self._config()
-        assert process_message("other/topic", b"data", config) is None
+    def test_non_meshtastic_topic_passthru(self):
+        config = _make_config(zerohop_channels=["LongFast"])
+        result = process_message("other/topic", b"data", config)
+        assert result.action == ACTION_PASSTHRU
 
     def test_msh_status_topic_silently_skipped(self):
-        config = self._config()
-        assert process_message("msh/US/CA", b"data", config) is None
+        config = _make_config(zerohop_channels=["LongFast"])
+        result = process_message("msh/US/CA", b"data", config)
+        assert result.action == ACTION_PASSTHRU
 
-    def test_whitelist_empty_zerohops_proto(self):
-        config = self._config(policy="whitelist")
+    def test_zerohops_listed_channel_proto(self):
+        config = _make_config(zerohop_channels=["LongFast"])
         with patch("floodgate.zerohop.zerohop_protobuf") as mock_zh:
             mock_zh.return_value = (b"modified", 3, {})
             result = process_message("msh/US/CA/2/e/LongFast/!1234", b"proto", config)
-        assert result == b"modified"
+        assert result.action == ACTION_MODIFY
+        assert result.payload == b"modified"
 
-    def test_whitelist_empty_zerohops_json(self):
-        config = self._config(policy="whitelist")
+    def test_zerohops_listed_channel_json(self):
+        config = _make_config(zerohop_channels=["LongFast"])
         with patch("floodgate.zerohop.zerohop_json") as mock_zh:
             mock_zh.return_value = (b'{"hop_limit":0}', 3, {})
             result = process_message("msh/US/CA/2/json/LongFast/!1234", b"json", config)
-        assert result == b'{"hop_limit":0}'
+        assert result.action == ACTION_MODIFY
+        assert result.payload == b'{"hop_limit":0}'
 
-    def test_whitelist_empty_zerohops_deep_topic(self):
-        config = self._config(policy="whitelist")
+    def test_zerohops_deep_topic(self):
+        config = _make_config(zerohop_channels=["LongFast"])
         with patch("floodgate.zerohop.zerohop_protobuf") as mock_zh:
             mock_zh.return_value = (b"modified", 3, {})
             result = process_message("msh/US/CA/BAY/2/e/LongFast/!16cec9ac", b"proto", config)
-        assert result == b"modified"
+        assert result.action == ACTION_MODIFY
 
-    def test_whitelist_bypasses_listed_channel(self):
-        config = self._config(policy="whitelist", whitelist=["MyChannel"])
+    def test_passes_through_unlisted_channel(self):
+        config = _make_config(zerohop_channels=["LongFast"])
         result = process_message("msh/US/2/e/MyChannel/!1234", b"proto", config)
-        assert result is None
+        assert result.action == ACTION_PASSTHRU
 
-    def test_whitelist_bypasses_listed_channel_json(self):
-        config = self._config(policy="whitelist", whitelist=["MyChannel"])
+    def test_passes_through_unlisted_channel_json(self):
+        config = _make_config(zerohop_channels=["LongFast"])
         result = process_message("msh/US/2/json/MyChannel/!1234", b"data", config)
-        assert result is None
+        assert result.action == ACTION_PASSTHRU
 
-    def test_blacklist_zerohops_listed(self):
-        config = self._config(policy="blacklist", blacklist=["LongFast"])
-        with patch("floodgate.zerohop.zerohop_protobuf") as mock_zh:
-            mock_zh.return_value = (b"modified", 3, {})
-            result = process_message("msh/US/2/e/LongFast/!1234", b"proto", config)
-        assert result == b"modified"
-
-    def test_blacklist_passes_unlisted(self):
-        config = self._config(policy="blacklist", blacklist=["LongFast"])
-        result = process_message("msh/US/2/e/MyChannel/!1234", b"proto", config)
-        assert result is None
-
-    def test_already_zero_returns_none(self):
-        config = self._config(policy="whitelist")
+    def test_already_zero_returns_passthru(self):
+        config = _make_config(zerohop_channels=["LongFast"])
         with patch("floodgate.zerohop.zerohop_protobuf") as mock_zh:
             mock_zh.return_value = (None, 0, {})
             result = process_message("msh/US/2/e/LongFast/!1234", b"proto", config)
-        assert result is None
+        assert result.action == ACTION_PASSTHRU
 
-    def test_parse_error_returns_none(self):
-        config = self._config(policy="whitelist")
+    def test_parse_error_returns_passthru(self):
+        config = _make_config(zerohop_channels=["LongFast"])
         with patch("floodgate.zerohop.zerohop_protobuf") as mock_zh:
             mock_zh.return_value = (None, None, {})
             result = process_message("msh/US/2/e/LongFast/!1234", b"bad", config)
-        assert result is None
+        assert result.action == ACTION_PASSTHRU
 
-    def test_json_string_node_ids_no_crash(self):
-        """JSON payloads with string node IDs must not crash _fmt_node."""
-        config = self._config(policy="whitelist")
-        meta = {"sender": "!f6acb04f", "destination": "!ffffffff", "packet_id": 99}
-        with patch("floodgate.zerohop.zerohop_json") as mock_zh:
-            mock_zh.return_value = (b'{"hop_limit":0}', 3, meta)
-            result = process_message("msh/US/2/json/LongFast/!f6acb04f", b"json", config)
-        assert result == b'{"hop_limit":0}'
+    def test_zerohop_disabled_passes_listed_channel(self):
+        config = _make_config(zerohop_enabled=False, zerohop_channels=["LongFast"])
+        result = process_message("msh/US/2/e/LongFast/!1234", b"proto", config)
+        assert result.action == ACTION_PASSTHRU
 
     def test_meta_fields_formatted(self):
-        config = self._config(policy="whitelist")
+        config = _make_config(zerohop_channels=["LongFast"])
         meta = {
             "packet_id":   0xDEADBEEF,
             "sender":      0xAABBCCDD,
@@ -275,11 +285,142 @@ class TestProcessMessage:
         with patch("floodgate.zerohop.zerohop_protobuf") as mock_zh:
             mock_zh.return_value = (b"modified", 3, meta)
             result = process_message("msh/US/2/e/LongFast/!1234", b"proto", config)
-        assert result == b"modified"
+        assert result.action == ACTION_MODIFY
+        assert result.payload == b"modified"
 
+
+# ---------------------------------------------------------------------------
+# Drop flow — runs before zerohop, returns ACTION_DROP
+# ---------------------------------------------------------------------------
+
+class TestProcessMessageDrop:
+
+    def _json_payload(self, *, type_="text"):
+        return json.dumps({
+            "from": 305419896, "to": 4294967295, "id": 999,
+            "hop_start": 5, "hops_away": 0, "type": type_,
+        }).encode()
+
+    def test_drops_matching_portnum_on_matching_channel(self, caplog):
+        config = _make_config(
+            zerohop_channels=["LongFast"],
+            drop_enabled=True,
+            drop_channels=["LongFast"],
+            drop_portnums=["TEXT_MESSAGE_APP"],
+        )
+        with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
+            result = process_message(
+                "msh/US/2/json/LongFast/!1234",
+                self._json_payload(type_="text"),
+                config,
+            )
+        assert result.action == ACTION_DROP
+        rec = [r for r in caplog.records if getattr(r, "outcome", None) == "dropped"]
+        assert len(rec) == 1
+        assert getattr(rec[0], "portnum") == "TEXT_MESSAGE_APP"
+        assert getattr(rec[0], "channel") == "LongFast"
+
+    def test_does_not_drop_non_matching_portnum(self):
+        config = _make_config(
+            zerohop_channels=["LongFast"],
+            drop_enabled=True,
+            drop_channels=["LongFast"],
+            drop_portnums=["RANGE_TEST_APP"],
+        )
+        with patch("floodgate.zerohop.zerohop_json") as mock_zh:
+            mock_zh.return_value = (b'{"hop_limit":0}', 3, {})
+            result = process_message(
+                "msh/US/2/json/LongFast/!1234",
+                self._json_payload(type_="text"),
+                config,
+            )
+        assert result.action == ACTION_MODIFY
+
+    def test_does_not_drop_off_channel(self):
+        config = _make_config(
+            drop_enabled=True,
+            drop_channels=["LongFast"],
+            drop_portnums=["TEXT_MESSAGE_APP"],
+        )
+        result = process_message(
+            "msh/US/2/json/MyChannel/!1234",
+            self._json_payload(type_="text"),
+            config,
+        )
+        assert result.action == ACTION_PASSTHRU
+
+    def test_drop_disabled_never_drops(self):
+        config = _make_config(
+            zerohop_channels=["LongFast"],
+            drop_enabled=False,
+            drop_channels=["LongFast"],
+            drop_portnums=["TEXT_MESSAGE_APP"],
+        )
+        with patch("floodgate.zerohop.zerohop_json") as mock_zh:
+            mock_zh.return_value = (b'{"hop_limit":0}', 3, {})
+            result = process_message(
+                "msh/US/2/json/LongFast/!1234",
+                self._json_payload(type_="text"),
+                config,
+            )
+        assert result.action == ACTION_MODIFY
+
+    def test_drop_runs_before_zerohop(self):
+        """Drop should short-circuit so zerohop_* is never called."""
+        config = _make_config(
+            zerohop_channels=["LongFast"],
+            drop_enabled=True,
+            drop_channels=["LongFast"],
+            drop_portnums=["TEXT_MESSAGE_APP"],
+        )
+        with patch("floodgate.zerohop.zerohop_json") as mock_zh:
+            mock_zh.return_value = (b'{"hop_limit":0}', 3, {})
+            result = process_message(
+                "msh/US/2/json/LongFast/!1234",
+                self._json_payload(type_="text"),
+                config,
+            )
+        assert result.action == ACTION_DROP
+        mock_zh.assert_not_called()
+
+    def test_drop_channels_none_means_all_channels(self):
+        config = _make_config(
+            drop_enabled=True,
+            drop_channels=None,
+            drop_portnums=["TEXT_MESSAGE_APP"],
+        )
+        # _make_config maps drop_channels=None → _drop_channels_set=None
+        result = process_message(
+            "msh/US/2/json/AnyChannel/!1234",
+            self._json_payload(type_="text"),
+            config,
+        )
+        assert result.action == ACTION_DROP
+
+    def test_unidentifiable_portnum_delivers(self):
+        """A JSON payload with no recognizable type can't be classified —
+        deliver (don't drop) since drop is destructive."""
+        config = _make_config(
+            zerohop_channels=["LongFast"],
+            drop_enabled=True,
+            drop_channels=["LongFast"],
+            drop_portnums=["TEXT_MESSAGE_APP"],
+        )
+        opaque = json.dumps({"from": 1, "to": 2, "id": 3, "hop_limit": 3,
+                             "hop_start": 3}).encode()
+        with patch("floodgate.zerohop.zerohop_json") as mock_zh:
+            mock_zh.return_value = (b'{"hop_limit":0}', 3, {})
+            result = process_message(
+                "msh/US/2/json/LongFast/!1234", opaque, config,
+            )
+        assert result.action == ACTION_MODIFY
+
+
+# ---------------------------------------------------------------------------
+# _peek_meta
+# ---------------------------------------------------------------------------
 
 class TestPeekMeta:
-    """Tests for _peek_meta — metadata extraction without payload modification."""
 
     def test_json_valid_returns_meta(self):
         payload = json.dumps({
@@ -287,215 +428,214 @@ class TestPeekMeta:
             "hop_start": 3, "via_mqtt": True,
         }).encode()
         meta = _peek_meta("json", payload)
-        assert meta["packet_id"] == 12345
-        assert meta["sender"] == 305419896
+        assert meta["packet_id"]   == 12345
+        assert meta["sender"]      == 305419896
         assert meta["destination"] == 4294967295
-        assert meta["hop_start"] == 3
-        assert meta["via_mqtt"] is True
+        assert meta["hop_start"]   == 3
+        assert meta["via_mqtt"]    is True
 
     def test_json_invalid_returns_empty(self):
-        meta = _peek_meta("json", b"not valid json {{")
-        assert meta == {}
+        assert _peek_meta("json", b"not valid json {{") == {}
 
     def test_json_empty_payload_returns_empty(self):
-        meta = _peek_meta("json", b"")
-        assert meta == {}
+        assert _peek_meta("json", b"") == {}
 
     def test_protobuf_invalid_returns_empty(self):
-        meta = _peek_meta("e", b"not a protobuf")
-        assert meta == {}
+        assert _peek_meta("e", b"not a protobuf") == {}
 
     def test_protobuf_empty_returns_empty(self):
-        meta = _peek_meta("e", b"")
-        assert meta == {}
+        assert _peek_meta("e", b"") == {}
 
     def test_passthru_log_includes_packet_id(self, caplog):
-        config = {
-            "channel_policy": "whitelist",
-            "_whitelist_set": {"LongFast"},
-            "_blacklist_set": set(),
-            "channel_whitelist": ["LongFast"],
-            "channel_blacklist": [],
-        }
+        config = _make_config(zerohop_channels=["LongFast"])
         payload = json.dumps({"id": 99999, "from": 1, "to": 4294967295,
                               "hop_start": 3, "hops_away": 0}).encode()
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
-            result = process_message("msh/US/2/json/LongFast/!aabbccdd", payload, config)
-        assert result is None
+            result = process_message(
+                "msh/US/2/json/MyPrivate/!aabbccdd", payload, config,
+            )
+        assert result.action == ACTION_PASSTHRU
         rec = caplog.records[-1]
-        assert getattr(rec, "id") == 99999
+        assert getattr(rec, "id")      == 99999
         assert getattr(rec, "outcome") == "passthru"
 
 
+# ---------------------------------------------------------------------------
+# Real-world JSON payloads through the full pipeline
+# ---------------------------------------------------------------------------
+
 class TestProcessMessageUnmockedJson:
     """Feed real JSON payloads through the full process_message path
-    WITHOUT mocking zerohop_json or zerohop_protobuf.  This exercises the
-    complete decode → modify → log pipeline end-to-end.
-    """
-
-    def _config(self, policy="whitelist", whitelist=None, blacklist=None):
-        return {
-            "channel_policy": policy,
-            "_whitelist_set": set(whitelist or []),
-            "_blacklist_set": set(blacklist or []),
-            "channel_whitelist": whitelist or [],
-            "channel_blacklist": blacklist or [],
-        }
+    WITHOUT mocking zerohop_json or zerohop_protobuf. This exercises the
+    complete decode → modify → log pipeline end-to-end."""
 
     def _json_payload(self, **overrides):
         """Standard Meshtastic JSON payload with integer node IDs."""
         data = {
-            "from": 305419896,       # 0x12345678
-            "to": 4294967295,        # 0xFFFFFFFF (broadcast)
-            "id": 1700391097,
+            "from":      305419896,
+            "to":        4294967295,
+            "id":        1700391097,
             "hop_start": 5,
             "hops_away": 0,
-            "channel": 1,
-            "type": "text",
+            "channel":   1,
+            "type":      "text",
         }
         data.update(overrides)
         return json.dumps(data).encode()
 
-    # -- Task 3: Standard cases ------------------------------------------------
-
     def test_zerohop_integer_node_ids(self, caplog):
-        config = self._config(policy="whitelist")
-        payload = self._json_payload()
+        config = _make_config(zerohop_channels=["LongFast"])
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
-            result = process_message("msh/US/2/json/LongFast/!12345678", payload, config)
-        assert result is not None
-        assert json.loads(result)["hop_limit"] == 0
+            result = process_message(
+                "msh/US/2/json/LongFast/!12345678", self._json_payload(), config,
+            )
+        assert result.action == ACTION_MODIFY
+        assert json.loads(result.payload)["hop_limit"] == 0
         rec = caplog.records[-1]
-        assert getattr(rec, "outcome") == "zerohop"
-        assert getattr(rec, "channel") == "LongFast"
+        assert getattr(rec, "outcome")  == "zerohop"
+        assert getattr(rec, "channel")  == "LongFast"
         assert getattr(rec, "encoding") == "json"
 
     def test_zerohop_string_node_ids(self, caplog):
         """Regression for #24: string node IDs must not crash _fmt_node."""
-        config = self._config(policy="whitelist")
+        config = _make_config(zerohop_channels=["LongFast"])
         data = {
-            "from": "!f6acb04f",
-            "to": "!ffffffff",
-            "id": 12345,
+            "from":      "!f6acb04f",
+            "to":        "!ffffffff",
+            "id":        12345,
             "hop_limit": 3,
             "hop_start": 3,
         }
-        payload = json.dumps(data).encode()
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
-            result = process_message("msh/US/2/json/LongFast/!f6acb04f", payload, config)
-        assert result is not None
+            result = process_message(
+                "msh/US/2/json/LongFast/!f6acb04f", json.dumps(data).encode(), config,
+            )
+        assert result.action == ACTION_MODIFY
         rec = caplog.records[-1]
-        assert getattr(rec, "outcome") == "zerohop"
-        assert getattr(rec, "from") == "!f6acb04f"
+        assert getattr(rec, "outcome")    == "zerohop"
+        assert getattr(rec, "from")       == "!f6acb04f"
 
     def test_noop_when_hops_away_equals_hop_start(self, caplog):
-        config = self._config(policy="whitelist")
+        config  = _make_config(zerohop_channels=["LongFast"])
         payload = self._json_payload(hop_start=5, hops_away=5)
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
-            result = process_message("msh/US/2/json/LongFast/!12345678", payload, config)
-        assert result is None
+            result = process_message(
+                "msh/US/2/json/LongFast/!12345678", payload, config,
+            )
+        assert result.action == ACTION_PASSTHRU
         rec = caplog.records[-1]
         assert getattr(rec, "outcome") == "noop"
 
     def test_explicit_hop_limit_zero_is_noop(self, caplog):
-        config = self._config(policy="whitelist")
+        config  = _make_config(zerohop_channels=["LongFast"])
         payload = self._json_payload(hop_limit=0)
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
-            result = process_message("msh/US/2/json/LongFast/!12345678", payload, config)
-        assert result is None
+            result = process_message(
+                "msh/US/2/json/LongFast/!12345678", payload, config,
+            )
+        assert result.action == ACTION_PASSTHRU
         rec = caplog.records[-1]
         assert getattr(rec, "outcome") == "noop"
 
     def test_missing_optional_fields(self, caplog):
-        config = self._config(policy="whitelist")
-        data = {"from": 305419896, "to": 4294967295, "id": 999, "hop_limit": 3}
-        payload = json.dumps(data).encode()
+        config = _make_config(zerohop_channels=["LongFast"])
+        data   = {"from": 305419896, "to": 4294967295, "id": 999, "hop_limit": 3}
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
-            result = process_message("msh/US/2/json/LongFast/!12345678", payload, config)
-        assert result is not None
-        assert json.loads(result)["hop_limit"] == 0
+            result = process_message(
+                "msh/US/2/json/LongFast/!12345678", json.dumps(data).encode(), config,
+            )
+        assert result.action == ACTION_MODIFY
+        assert json.loads(result.payload)["hop_limit"] == 0
         rec = caplog.records[-1]
-        assert getattr(rec, "outcome") == "zerohop"
+        assert getattr(rec, "outcome")   == "zerohop"
         assert getattr(rec, "hop_start") is None
 
-    def test_malformed_json_returns_none(self, caplog):
-        config = self._config(policy="whitelist")
+    def test_malformed_json_returns_passthru(self, caplog):
+        config = _make_config(zerohop_channels=["LongFast"])
         with caplog.at_level(logging.WARNING, logger="floodgate.zerohop"):
             result = process_message(
                 "msh/US/2/json/LongFast/!12345678",
                 b"not valid json {{{{",
                 config,
             )
-        assert result is None
+        assert result.action == ACTION_PASSTHRU
         rec = caplog.records[-1]
         assert getattr(rec, "outcome") == "warn"
 
     def test_partial_json_missing_required_hop_fields(self, caplog):
         """Payload with from/to/id but no hop_limit/hop_start/hops_away → noop."""
-        config = self._config(policy="whitelist")
-        data = {"from": 305419896, "to": 4294967295, "id": 42}
-        payload = json.dumps(data).encode()
+        config = _make_config(zerohop_channels=["LongFast"])
+        data   = {"from": 305419896, "to": 4294967295, "id": 42}
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
-            result = process_message("msh/US/2/json/LongFast/!12345678", payload, config)
-        assert result is None
+            result = process_message(
+                "msh/US/2/json/LongFast/!12345678", json.dumps(data).encode(), config,
+            )
+        assert result.action == ACTION_PASSTHRU
         rec = caplog.records[-1]
         assert getattr(rec, "outcome") == "noop"
 
     def test_edge_case_from_zero(self, caplog):
-        config = self._config(policy="whitelist")
+        config  = _make_config(zerohop_channels=["LongFast"])
         payload = self._json_payload(**{"from": 0})
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
-            result = process_message("msh/US/2/json/LongFast/!00000000", payload, config)
-        assert result is not None
+            result = process_message(
+                "msh/US/2/json/LongFast/!00000000", payload, config,
+            )
+        assert result.action == ACTION_MODIFY
         rec = caplog.records[-1]
         assert getattr(rec, "from") == "!00000000"
 
     def test_edge_case_to_zero(self, caplog):
-        config = self._config(policy="whitelist")
+        config  = _make_config(zerohop_channels=["LongFast"])
         payload = self._json_payload(to=0)
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
-            result = process_message("msh/US/2/json/LongFast/!12345678", payload, config)
-        assert result is not None
+            result = process_message(
+                "msh/US/2/json/LongFast/!12345678", payload, config,
+            )
+        assert result.action == ACTION_MODIFY
         rec = caplog.records[-1]
         assert getattr(rec, "to") == "!00000000"
 
-    # -- Task 4: Passthru path ------------------------------------------------
+    # -- Passthru path --------------------------------------------------------
 
     def test_passthru_with_real_payload(self, caplog):
-        config = self._config(policy="whitelist", whitelist=["LongFast"])
-        payload = self._json_payload()
+        # Channel not in zerohop_channels → passthru
+        config = _make_config(zerohop_channels=["MediumFast"])
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
-            result = process_message("msh/US/2/json/LongFast/!12345678", payload, config)
-        assert result is None
+            result = process_message(
+                "msh/US/2/json/LongFast/!12345678", self._json_payload(), config,
+            )
+        assert result.action == ACTION_PASSTHRU
         rec = caplog.records[-1]
         assert getattr(rec, "outcome") == "passthru"
-        assert getattr(rec, "id") == 1700391097
+        assert getattr(rec, "id")      == 1700391097
 
     def test_passthru_string_node_ids(self, caplog):
-        """Passthru with string node IDs must not crash _fmt_node."""
-        config = self._config(policy="whitelist", whitelist=["LongFast"])
-        data = {
-            "from": "!f6acb04f",
-            "to": "!ffffffff",
-            "id": 12345,
+        config = _make_config(zerohop_channels=["MediumFast"])
+        data   = {
+            "from":      "!f6acb04f",
+            "to":        "!ffffffff",
+            "id":        12345,
             "hop_limit": 3,
             "hop_start": 3,
         }
-        payload = json.dumps(data).encode()
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
-            result = process_message("msh/US/2/json/LongFast/!f6acb04f", payload, config)
-        assert result is None
+            result = process_message(
+                "msh/US/2/json/LongFast/!f6acb04f", json.dumps(data).encode(), config,
+            )
+        assert result.action == ACTION_PASSTHRU
         rec = caplog.records[-1]
         assert getattr(rec, "outcome") == "passthru"
-        assert getattr(rec, "from") == "!f6acb04f"
+        assert getattr(rec, "from")    == "!f6acb04f"
 
-    def test_blacklist_zerohop_json(self, caplog):
-        config = self._config(policy="blacklist", blacklist=["LongFast"])
-        payload = self._json_payload()
+    def test_zerohop_listed_channel_json(self, caplog):
+        config = _make_config(zerohop_channels=["LongFast"])
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
-            result = process_message("msh/US/2/json/LongFast/!12345678", payload, config)
-        assert result is not None
-        assert json.loads(result)["hop_limit"] == 0
+            result = process_message(
+                "msh/US/2/json/LongFast/!12345678", self._json_payload(), config,
+            )
+        assert result.action == ACTION_MODIFY
+        assert json.loads(result.payload)["hop_limit"] == 0
         rec = caplog.records[-1]
         assert getattr(rec, "outcome") == "zerohop"
 
@@ -505,21 +645,19 @@ class TestProcessMessageUnmockedJson:
         ids=lambda p: p.stem,
     )
     def test_real_world_payload_smoke(self, payload_path, caplog):
-        """Smoke test: every JSON file in tests/payloads/ must pass through
+        """Every JSON file in tests/payloads/ must pass through
         process_message without crashing and produce exactly one valid
         outcome record. Drop new samples into the directory to extend
-        coverage automatically.
-        """
-        config = self._config(policy="whitelist")
-        payload = payload_path.read_bytes()
+        coverage automatically."""
+        config = _make_config(zerohop_channels=["LongFast"])
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
             process_message(
-                "msh/US/2/json/LongFast/!00000000", payload, config,
+                "msh/US/2/json/LongFast/!00000000", payload_path.read_bytes(), config,
             )
         outcome_records = [r for r in caplog.records if hasattr(r, "outcome")]
         assert len(outcome_records) == 1
         assert getattr(outcome_records[0], "outcome") in (
-            "zerohop", "noop", "passthru", "warn",
+            "zerohop", "noop", "passthru", "warn", "dropped",
         )
 
     def test_range_test_app_real_world_payload(self, caplog):
@@ -530,28 +668,51 @@ class TestProcessMessageUnmockedJson:
         1. Gateway-published JSON nests hop_limit inside `payload`, not at
            the top level. zerohop_json only inspects the top level, so this
            packet is treated as already zero-hopped (noop) and passes
-           through unchanged. Tracking issue: #29 (portnum-based blacklist).
+           through unchanged. (To actually filter range-test traffic, use
+           the drop_portnums setting.)
 
         2. The JSON has both `from` (originating node, decimal int) and
            `sender` (publishing gateway, !hex string) — they may differ.
            floodgate reads `from` for its log fields.
         """
-        config = self._config(policy="whitelist")
+        config = _make_config(zerohop_channels=["LongFast"])
         payload = _load_json_payload("range_test_app.json")
-        # Gateway publishes on its own !sender topic
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
             result = process_message(
-                "msh/US/2/json/LongFast/!cc00000a", payload, config,
+                "msh/US/2/json/LongFast/!9d5f3af4", payload, config,
             )
-        assert result is None
+        assert result.action == ACTION_PASSTHRU
         rec = [r for r in caplog.records if getattr(r, "outcome", None) == "noop"]
         assert len(rec) == 1
-        assert getattr(rec[0], "id") == 1455581347
-        # `from` is sourced from JSON's `from` field (originating node), not `sender`
-        assert getattr(rec[0], "from") == "!aa00000a"
-        assert getattr(rec[0], "to") == "!ffffffff"
+        assert getattr(rec[0], "id")        == 1455581347
+        # `from` field of the fixture (anonymized to 0xaa00000a)
+        assert getattr(rec[0], "from")      == "!aa00000a"
+        assert getattr(rec[0], "to")        == "!ffffffff"
         assert getattr(rec[0], "hop_limit") == 0
 
+    def test_range_test_app_dropped_when_configured(self, caplog):
+        """End-to-end: drop_portnums actually drops the real-world
+        gateway-published RANGE_TEST_APP payload by reading the nested
+        portnum field."""
+        config = _make_config(
+            zerohop_channels=["LongFast"],
+            drop_enabled=True,
+            drop_portnums=["RANGE_TEST_APP"],
+        )
+        payload = _load_json_payload("range_test_app.json")
+        with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
+            result = process_message(
+                "msh/US/2/json/LongFast/!9d5f3af4", payload, config,
+            )
+        assert result.action == ACTION_DROP
+        rec = [r for r in caplog.records if getattr(r, "outcome", None) == "dropped"]
+        assert len(rec) == 1
+        assert getattr(rec[0], "portnum") == "RANGE_TEST_APP"
+
+
+# ---------------------------------------------------------------------------
+# Real-world protobuf payloads
+# ---------------------------------------------------------------------------
 
 try:
     import meshtastic  # noqa: F401
@@ -566,22 +727,7 @@ except ImportError:
 )
 class TestProcessMessageUnmockedProtobuf:
     """Full-path tests: real binary /e/ ServiceEnvelope payloads through
-    process_message, no mocks. Exercises zerohop_protobuf end-to-end
-    against samples captured from the public broker.
-
-    The /e/ topic is what Meshtastic firmware actually uses on the mesh —
-    /json/ is a debug mirror published by some gateways. These tests
-    exercise the path that matters for production behavior.
-    """
-
-    def _config(self, policy="whitelist", whitelist=None, blacklist=None):
-        return {
-            "channel_policy": policy,
-            "_whitelist_set": set(whitelist or []),
-            "_blacklist_set": set(blacklist or []),
-            "channel_whitelist": whitelist or [],
-            "channel_blacklist": blacklist or [],
-        }
+    process_message, no mocks."""
 
     @pytest.mark.parametrize(
         "payload_path",
@@ -589,19 +735,50 @@ class TestProcessMessageUnmockedProtobuf:
         ids=lambda p: p.stem,
     )
     def test_real_world_payload_smoke(self, payload_path, caplog):
-        """Smoke test: every .bin file in tests/payloads/protobuf/ must
-        pass through process_message without crashing and produce exactly
-        one valid outcome record. Drop new samples into the directory to
-        extend coverage automatically.
-        """
-        config = self._config(policy="whitelist")
-        payload = payload_path.read_bytes()
+        """Every .bin file in tests/payloads/protobuf/ must pass through
+        process_message without crashing and produce exactly one valid
+        outcome record."""
+        config = _make_config(zerohop_channels=["LongFast"])
         with caplog.at_level(logging.INFO, logger="floodgate.zerohop"):
             process_message(
-                "msh/US/2/e/LongFast/!00000000", payload, config,
+                "msh/US/2/e/LongFast/!00000000", payload_path.read_bytes(), config,
             )
         outcome_records = [r for r in caplog.records if hasattr(r, "outcome")]
         assert len(outcome_records) == 1
         assert getattr(outcome_records[0], "outcome") in (
-            "zerohop", "noop", "passthru", "warn",
+            "zerohop", "noop", "passthru", "warn", "dropped",
         )
+
+
+# ---------------------------------------------------------------------------
+# AntifloodStats — counter mechanics
+# ---------------------------------------------------------------------------
+
+class TestAntifloodStats:
+
+    def setup_method(self):
+        # Fresh counters per test — both rolling and lifetime
+        with packet_stats._lock:
+            for k in ("zerohop", "passthru", "noop", "dropped", "skipped", "errors"):
+                setattr(packet_stats, k, 0)
+                packet_stats._lifetime[k] = 0
+
+    def test_inc_increments_both_views(self):
+        packet_stats.inc("dropped")
+        assert packet_stats.dropped == 1
+        assert packet_stats.snapshot()["dropped"] == 1
+
+    def test_reset_zeros_rolling_keeps_lifetime(self):
+        for _ in range(3):
+            packet_stats.inc("dropped")
+        snap = packet_stats.reset()
+        assert snap["dropped"]                   == 3
+        assert packet_stats.dropped              == 0
+        assert packet_stats.snapshot()["dropped"] == 3
+
+    def test_total_includes_dropped(self):
+        packet_stats.inc("zerohop")
+        packet_stats.inc("dropped")
+        packet_stats.inc("dropped")
+        snap = packet_stats.snapshot()
+        assert snap["total"] == 3


### PR DESCRIPTION
## Summary

Closes #29.

Splits the channel-policy concept into two independent operations:

- **Zerohop** — `zerohop_enabled` / `zerohop_channels`. Modifies `hop_limit` to 0 and delivers (existing behavior under new names).
- **Drop** — `drop_enabled` / `drop_channels` / `drop_portnums`. Denies the publish entirely via EMQX `allow_publish: false` header. Runs **before** zerohop.

`drop_channels` accepts the literal string `"zerohop_channels"` to inherit the same scope, an explicit list, or `null`/empty for all channels. The pre-rename `channel_policy` / `channel_blacklist` / `channel_whitelist` keys trigger `ConfigError` at startup with the rename mapping — no migration shim, this is pre-1.0.

Drop reads the portnum from `/e/` packets via AES-128-CTR decryption with the canonical Meshtastic default key (PSK `AQ==`). Custom-keyed channels are unreadable and therefore always delivered. JSON `/json/` payloads expose the portnum directly, no decryption needed.

New `dropped` outcome flows through stats, the `/health` endpoint, structured logs (text and JSON), and the CLI verbose-help text.

## What's where

- New: `src/floodgate/decrypt.py` (AES-128-CTR with the documented Meshtastic default key + nonce layout, sourced from upstream firmware `CryptoEngine.cpp`)
- New: `src/floodgate/portnum.py` (extract portnum from `/e/` and `/json/` payloads)
- New: `tests/test_decrypt.py`, `tests/test_portnum.py`
- Modified: `config.py`, `zerohop.py`, `exhook_server.py`, `log_setup.py`, `__main__.py`, plus all touched tests, configs, and docs

`process_message` now returns a `ProcessResult(action, payload)` with action ∈ `{modify, drop, passthru}`; the gRPC layer maps each to the appropriate ExHook response.

## Verification

- 200 unit tests pass (was 110 before this PR; +90 new, mostly drop flow + decrypt + portnum)
- 6 container smoke tests pass (Docker rebuild verifies the new `cryptography>=42` dep and the new schema in the bundled `config.yaml`)
- `ruff check src/ tests/` clean
- End-to-end manual: real-world `range_test_app.json` fixture with `drop_portnums: ["RANGE_TEST_APP"]` returns `ACTION_DROP`; bad config with old `channel_policy` key fails at startup with the documented migration message; passthru/modify paths work
- An independent code-review agent cross-checked the AES key + nonce layout against upstream Meshtastic and the `STOP_AND_RETURN` + `allow_publish: false` pattern against EMQX's official ExHook examples — its two minor suggestions (string-list validation, README note about EMQX still ACKing dropped publishes) are incorporated

## Test plan

- [ ] Reviewer: read `src/floodgate/decrypt.py` and confirm the default key (`d4f1bb3a20290759f0bcffabcf4e6901`) and nonce layout match what's expected from upstream Meshtastic
- [ ] Reviewer: confirm the drop flow in `src/floodgate/zerohop.py::_process_message_inner` runs before zerohop and short-circuits correctly
- [ ] Reviewer: skim the README "Drop" section for clarity around the encryption constraint and the EMQX ACK behavior
- [ ] CI: lint, unit tests across Python 3.11/3.12/3.13, container smoke, k8s manifest validation

## Follow-ups

- #37 tracks small test-suite cleanups (~25-30% redundancy, one missing protobuf E2E test, `pytest-xdist` future-proofing). Non-blocking.
- Issue #28 (live emqx + floodgate + 2× meshtasticd docker-compose validation env) is the natural next step but separate scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)