### PR TITLE
chore: untrack .env and gitignore all .env* files

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,0 @@
-# Project-level dev environment vars. Source before working in the repo:
-#   set -a; . ./.env; set +a
-# (or use direnv / your editor's .env loader)
-#
-# Don't put secrets here — this file is committed. Personal overrides go in
-# .env.local, which is gitignored.
-
-# Stop Python from writing __pycache__/ trees in the working tree.
-PYTHONDONTWRITEBYTECODE=1

--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,9 @@ build/
 .venv/
 venv/
 
-# Personal env overrides — the tracked .env carries shared dev-convenience
-# vars (PYTHONDONTWRITEBYTECODE etc.); .env.local is for per-developer extras
-# and stays out of git. Don't put secrets in either; floodgate has no secret
-# config.
-.env.local
+# Local env files — never commit. Even if floodgate has no required secrets,
+# treating dotenv files as private prevents accidental leaks.
+.env*
 
 # Test caches and coverage artefacts
 .pytest_cache/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,8 @@ Every PR and push to `main` runs five jobs in sequence:
 ### Running locally
 
 ```bash
-# Source the project .env once per shell to pick up dev-convenience vars
-# (currently just PYTHONDONTWRITEBYTECODE=1 to keep __pycache__ out of the
-# working tree). direnv users can skip this — direnv loads it automatically.
-set -a; . ./.env; set +a
+# Optional: keep __pycache__ out of the working tree.
+export PYTHONDONTWRITEBYTECODE=1
 
 # Unit tests (fast, no Docker needed). Protobuf-dependent tests skip
 # automatically if you haven't generated stubs yet.


### PR DESCRIPTION
## Summary

Remove the previously-tracked `.env` from the index and broaden the gitignore pattern to `.env*` so all dotenv variants stay out of git.

The committed `.env` only held a non-secret `PYTHONDONTWRITEBYTECODE=1` hint with a "no secrets here" comment, so this isn't a credential leak. But committing any `.env` is a foot-gun: it normalizes the practice and makes it trivial for a future contributor to drop a real secret in unaware. Belt-and-suspenders.

## Changes

- `git rm .env` — file no longer tracked
- `.gitignore` — `.env.local` line replaced with `.env*` (covers `.env`, `.env.local`, `.env.production`, etc.)
- `CONTRIBUTING.md` — replaced the `set -a; . ./.env; set +a` instruction with an inline `export PYTHONDONTWRITEBYTECODE=1` so the dev-convenience survives without the tracked file

## Test plan

- [x] `git check-ignore -v .env .env.local .env.production` — all three caught by the new pattern
- [ ] CI lint + unit tests pass (no behavior change; .env was never used by code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)